### PR TITLE
Add support for AWS EMR

### DIFF
--- a/api/services/elastigroup/aws/emr/parameters/mrScalerId.yaml
+++ b/api/services/elastigroup/aws/emr/parameters/mrScalerId.yaml
@@ -1,0 +1,8 @@
+in: path
+name: MrScalerId
+required: true
+description: >
+  The MRScaler ID
+schema:
+  type: string
+example: "simrs-12223"

--- a/api/services/elastigroup/aws/emr/paths/mr-scaler-cluster.yaml
+++ b/api/services/elastigroup/aws/emr/paths/mr-scaler-cluster.yaml
@@ -1,0 +1,14 @@
+get:
+  summary: "Elastigroup AWS EMR - List All MR Scaler Clusters"
+  description: Get a list of all MR Scaler clusters
+  operationId: "elastigroupAwsEmrListMrScalerClusters"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+  responses:
+    200:
+      $ref: "../responses/mr-scaler-cluster.yaml"
+    400:
+      description: "Bad Request"

--- a/api/services/elastigroup/aws/emr/paths/mr-scaler-costs.yaml
+++ b/api/services/elastigroup/aws/emr/paths/mr-scaler-costs.yaml
@@ -1,0 +1,16 @@
+get:
+  summary: "Elastigroup AWS EMR - MR Scaler Costs"
+  description: Get financial information on the MR Scaler, including running time, costs, and savings
+  operationId: "elastigroupAwsEmrListMrScalerCosts"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../../../../../commons/parameters/fromDateUnixEnabled.yaml"
+    - $ref: "../../../../../commons/parameters/toDateUnixEnabled.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+  responses:
+    200:
+      $ref: "../responses/mr-scaler-costs.yaml"
+    400:
+      description: "Bad Request"

--- a/api/services/elastigroup/aws/emr/paths/mr-scaler-instance.yaml
+++ b/api/services/elastigroup/aws/emr/paths/mr-scaler-instance.yaml
@@ -1,0 +1,14 @@
+get:
+  summary: "Elastigroup AWS EMR - List Instances"
+  description: Get a list of all instances and instances groups in the cluster
+  operationId: "elastigroupAwsEmrListInstances"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+  responses:
+    200:
+      $ref: "../responses/mr-scaler-instance.yaml"
+    400:
+      description: "Bad Request"

--- a/api/services/elastigroup/aws/emr/paths/mr-scaler-scale-down.yaml
+++ b/api/services/elastigroup/aws/emr/paths/mr-scaler-scale-down.yaml
@@ -1,0 +1,20 @@
+put:
+  summary: "Elastigroup AWS EMR - Scale Down"
+  description: Scale down MR Scaler instances
+  operationId: "elastigroupAwsEmrScaleDown"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+    - in: query
+      name: adjustment
+      description: Number of instances to remove from the MR Scaler
+      type: integer
+      example: 3
+      required: true
+  responses:
+    200:
+      $ref: "../responses/mr-scaler-scale-down.yaml"
+    400:
+      description: "Bad Request"

--- a/api/services/elastigroup/aws/emr/paths/mr-scaler-scale-up.yaml
+++ b/api/services/elastigroup/aws/emr/paths/mr-scaler-scale-up.yaml
@@ -1,0 +1,20 @@
+put:
+  summary: "Elastigroup AWS EMR - Scale Up"
+  description: Scale up MR Scaler instances
+  operationId: "elastigroupAwsEmrScaleUp"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+    - in: query
+      name: adjustment
+      description: Number of instances to add to the MR Scaler
+      type: integer
+      example: 3
+      required: true
+  responses:
+    200:
+      $ref: "../responses/mr-scaler-scale-up.yaml"
+    400:
+      description: "Bad Request"

--- a/api/services/elastigroup/aws/emr/paths/mr-scaler.yaml
+++ b/api/services/elastigroup/aws/emr/paths/mr-scaler.yaml
@@ -1,0 +1,53 @@
+get:
+  summary: "Elastigroup AWS EMR - List MR Scaler"
+  description: Get a description of a specific MR Scaler and its configuration.
+  operationId: "elastigroupAwsEmrListScaler"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+  responses:
+    200:
+      $ref: "../responses/mr-scaler.yaml#/responses/mrScalerwithCreatedAtUpdatedAt"
+    400:
+      description: "Bad Request"
+
+put:
+  summary: "Elastigroup AWS EMR - Update MR Scaler"
+  description: Update an MR Scaler. Partial updating is supported.
+  operationId: "elastigroupAwsEmrUpdateScaler"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - $ref: "../schemas/put-partial-updates/put-partial-capacity.yaml"
+            - $ref: "../schemas/put-partial-updates/put-partial-dynamic-volume-in-ebs.yaml"
+  responses:
+    200:
+      $ref: "../responses/mr-scaler.yaml#/responses/mrScalerwithCreatedAtUpdatedAt"
+    400:
+      description: "Bad Request"
+
+delete:
+  summary: "Elastigroup AWS EMR - Delete MR Scaler"
+  description: Delete an MR Scaler
+  operationId: "elastigroupAwsEmrDeleteMrsScaler"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+    - $ref: "../parameters/mrScalerId.yaml"
+  responses:
+    200:
+      $ref: "../../../../../commons/responses/spotinstResponseWrapper.yaml"
+    400:
+      description: "Bad Request"
+

--- a/api/services/elastigroup/aws/emr/paths/mr-scalers.yaml
+++ b/api/services/elastigroup/aws/emr/paths/mr-scalers.yaml
@@ -1,0 +1,34 @@
+get:
+  summary: "Elastigroup AWS EMR - List All MR Scalers"
+  description: List all MR Scalers and their configuration.
+  operationId: "elastigroupAwsEmrListAll"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+  responses:
+    200:
+      $ref: "../responses/mr-scaler.yaml#/responses/mrScalerwithCreatedAtUpdatedAt"
+    400:
+      description: "Bad Request"
+
+post:
+  summary: "Elastigroup AWS EMR - Create"
+  description: Create a new EMR cluster.
+  operationId: "elastigroupAwsEmrCreate"
+  tags:
+    - "Elastigroup AWS EMR"
+  parameters:
+    - $ref: "../../../../../commons/parameters/accountId.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: "../schemas/mrScaler.yaml"
+  responses:
+    200:
+      $ref: "../responses/mr-scaler.yaml#/responses/mrScaler"
+    400:
+      description: "Bad Request"

--- a/api/services/elastigroup/aws/emr/responses/mr-scaler-cluster.yaml
+++ b/api/services/elastigroup/aws/emr/responses/mr-scaler-cluster.yaml
@@ -1,0 +1,17 @@
+description: Elastigroup Response
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../../commons/schemas/spotinstResponseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/cluster/mr-scaler-cluster-status.yaml"
+                kind:
+                  example: "spotinst:aws:emr:mrScaler:cluster"

--- a/api/services/elastigroup/aws/emr/responses/mr-scaler-costs.yaml
+++ b/api/services/elastigroup/aws/emr/responses/mr-scaler-costs.yaml
@@ -1,0 +1,17 @@
+description: Elastigroup Response
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../../commons/schemas/spotinstResponseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/costs/mr-scaler-costs.yaml"
+                kind:
+                  example: "spotinst:aws:emr:mrScaler:costs"

--- a/api/services/elastigroup/aws/emr/responses/mr-scaler-instance.yaml
+++ b/api/services/elastigroup/aws/emr/responses/mr-scaler-instance.yaml
@@ -1,0 +1,17 @@
+description: Elastigroup Response
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../../commons/schemas/spotinstResponseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/instance/instance.yaml"
+                kind:
+                  example: "spotinst:aws:emr:mrScaler:instance"

--- a/api/services/elastigroup/aws/emr/responses/mr-scaler-scale-down.yaml
+++ b/api/services/elastigroup/aws/emr/responses/mr-scaler-scale-down.yaml
@@ -1,0 +1,17 @@
+description: Elastigroup Response
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../../commons/schemas/spotinstResponseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/scale/scale-down.yaml"
+                kind:
+                  example: "spotinst:aws:emr:mrScaler:scale"

--- a/api/services/elastigroup/aws/emr/responses/mr-scaler-scale-up.yaml
+++ b/api/services/elastigroup/aws/emr/responses/mr-scaler-scale-up.yaml
@@ -1,0 +1,17 @@
+description: Elastigroup Response
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../../commons/schemas/spotinstResponseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/scale/scale-up.yaml"
+                kind:
+                  example: "spotinst:aws:emr:mrScaler:scale"

--- a/api/services/elastigroup/aws/emr/responses/mr-scaler.yaml
+++ b/api/services/elastigroup/aws/emr/responses/mr-scaler.yaml
@@ -1,0 +1,40 @@
+responses:
+  mrScaler:
+    description: Elastigroup Response
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: "../../../../../commons/schemas/spotinstResponseItemWrapper.yaml"
+            - type: object
+              properties:
+                response:
+                  type: object
+                  properties:
+                    items:
+                      type: array
+                      items:
+                        $ref: "../schemas/mrScaler.yaml"
+                    kind:
+                      example: "spotinst:aws:emr:mrScaler"
+
+  mrScalerwithCreatedAtUpdatedAt:
+    description: Elastigroup Response
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: "../../../../../commons/schemas/spotinstResponseItemWrapper.yaml"
+            - type: object
+              properties:
+                response:
+                  type: object
+                  properties:
+                    items:
+                      type: array
+                      items:
+                        allOf:
+                          - $ref: "../schemas/mrScaler.yaml"
+                          - $ref: "../schemas/commons/createdAtUpdatedAt.yaml"
+                    kind:
+                      example: "spotinst:aws:emr:mrScaler"

--- a/api/services/elastigroup/aws/emr/schemas/cluster.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/cluster.yaml
@@ -1,0 +1,40 @@
+type: object
+title: EMR Cluster Object
+description: >
+  **Allowed only when the `new` strategy is chosen.**
+properties:
+  terminationProtected:
+    type: boolean
+    description: >
+      Specifies whether the Amazon EC2 instances in the cluster are protected from
+      termination by API calls, user intervention, or in the event of a job-flow error
+    example: false
+  keepJobFlowAliveWhenNoSteps:
+    type: boolean
+    description: Specifies whether the cluster should remain available after completing all steps
+    example: true
+  logUri:
+    type: string
+    description: The path to the Amazon S3 location where logs for this cluster are stored.
+    example: "s3://job-status"
+  additionalInfo:
+    type: string
+    description: >
+      This is meta information about third-party applications
+      that third-party vendors use for testing purposes.
+    example: "{'test':'more information'}"
+  jobFlowRole:
+    type: string
+    description: >
+      The IAM role that was specified when the job flow was launched.
+      The EC2 instances of the job flow assume this role.
+    example: "EMR_EC2_DefaultRole"
+  serviceRole:
+    type: string
+    description: >
+      The IAM role that will be assumed by the Amazon EMR service to access AWS resources on your behalf
+    example: "someIAMRole"
+  securityConfiguration:
+    type: string
+    description: The name of the security configuration applied to the cluster
+    example: "testConfig"

--- a/api/services/elastigroup/aws/emr/schemas/cluster/mr-scaler-cluster-status.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/cluster/mr-scaler-cluster-status.yaml
@@ -1,0 +1,26 @@
+type: object
+title: "MR Scaler Cluster Object"
+description: "An MR Scaler cluster"
+properties:
+  id:
+    type: string
+    description: "The cluster's ID"
+    example: "j-3N7WPI3R0D1R7"
+  availabilityZone:
+    type: string
+    description: "The cluster's AZ"
+    example: "us-east-1a"
+  state:
+    type: string
+    description: "The cluster's state"
+    example: "terminated"
+  createdAt:
+    type: string
+    format: date-time
+    description: "The date-time this cluster was created"
+    example: "2015-08-02T09:11:16.356Z"
+  updatedAt:
+    type: string
+    format: date-time
+    description: "The date-time this cluster was last updated"
+    example: "2015-08-02T10:11:16.356Z"

--- a/api/services/elastigroup/aws/emr/schemas/commons/createdAtUpdatedAt.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/commons/createdAtUpdatedAt.yaml
@@ -1,0 +1,11 @@
+type: object
+title: "createdAt & updatedAt object"
+properties:
+  updatedAt:
+    type: string
+    format: date-time
+    example: "2018-02-07T10:50:29.000+0000"
+  createdAt:
+    type: string
+    format: date-time
+    example: "2018-02-07T10:50:29.000+0000"

--- a/api/services/elastigroup/aws/emr/schemas/compute/application.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/application.yaml
@@ -1,0 +1,17 @@
+type: object
+title: Application Object
+description: Application for Amazon EMR to install and configure when launching the cluster
+properties:
+  name:
+    type: string
+    description: Application name
+    example: "Hue"
+  args:
+    type: array
+    description: Application arguments
+    items:
+      type: string
+  version:
+    type: string
+    description: Application version
+    example: "1.0"

--- a/api/services/elastigroup/aws/emr/schemas/compute/availabilityZone.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/availabilityZone.yaml
@@ -1,0 +1,14 @@
+type: object
+title: AZ Object
+description: Availability Zone object
+properties:
+  name:
+    type: string
+    description: >
+      AZ name - **required in clone strategy only**
+    example: "us-west-2a"
+  subnetId:
+    type: string
+    description: >
+      EC2/VPC subnet ID - **required in clone strategy only**
+    example: "subnet-3b5b3601"

--- a/api/services/elastigroup/aws/emr/schemas/compute/bootstrapActions.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/bootstrapActions.yaml
@@ -1,0 +1,20 @@
+type: object
+title: BootstrapActions Object
+description: >
+  Describe bootstrap actions.
+  For more information please see:
+  [Advanced - Using Bootstrap And Configuration Files](https://help.spot.io/elastigroup-for-aws/services-integrations/elastic-mapreduce/import-an-emr-cluster/advanced/)
+properties:
+  file:
+    type: object
+    description: Bootstrap file information
+    properties:
+      bucket:
+        type: string
+        description: The S3 bucket name
+        example: "emr-test"
+      key:
+        type: string
+        description: The S3 Bucket key
+        example: "MyFile.json"
+

--- a/api/services/elastigroup/aws/emr/schemas/compute/compute.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/compute.yaml
@@ -1,0 +1,92 @@
+type: object
+title: "Compute Object"
+description: describes the compute resources for the MR scaler
+properties:
+  ebsRootVolumeSize:
+    type: integer
+    description: The EBS root volume size in GB
+    example: 4
+  availabilityZones:
+    type: array
+    description: Array of availability zone objects
+    items:
+      $ref: "./availabilityZone.yaml"
+  bootstrapActions:
+    $ref: "./bootstrapActions.yaml"
+  instanceGroups:
+    type: array
+    description: Array of instance groups for this MR scaler
+    items:
+      $ref: "./instanceGroup.yaml"
+  instanceWeights:
+    type: array
+    description: An array of custom-weight settings
+    items:
+      $ref: "./instanceWeight.yaml"
+  emrManagedMasterSecurityGroup:
+    type: string
+    description: EMR Managed Security group that will be set to the master instance group
+    example: "sg-123456789"
+  emrManagedSlaveSecurityGroup:
+      type: string
+      description: EMR Managed Security group that will be set to the slave instance group
+      example: "sg-123456789"
+  additionalMasterSecurityGroups:
+    type: array
+    description: A list of additional Amazon EC2 security group IDs for the master node.
+    items:
+      type: string
+    example: ["sg-123456789"]
+  additionalSlaveSecurityGroups:
+    type: array
+    description: A list of additional Amazon EC2 security group IDs for the core and task nodes.
+    items:
+      type: string
+    example: ["sg-123456789"]
+  serviceAccessSecurityGroup:
+      type: string
+      description: >
+        The identifier of the Amazon EC2 security group for the Amazon EMR service to access
+        clusters in VPC private subnets
+      example: "EMR_DefaultRole"
+  customAmiId:
+    type: string
+    description: The ID of a custom Amazon EBS-backed Linux AMI if the cluster uses a custom AMI.
+    example: "ami-123456789"
+  repoUpgradeOnBoot:
+    type: string
+    description: >
+      **Applies only when CustomAmiID is used**.
+      Specifies the type of updates that are applied from the Amazon Linux AMI package repositories
+      when an instance boots using the AMI.
+    enum: ["SECURITY", "NONE"]
+    example: "SECURITY"
+  tags:
+    type: array
+    description: >
+      array of key:value pairs of tags
+    items:
+      type: object
+      properties:
+        tagKey:
+          type: string
+          description: The tag's key
+          example: "Creator"
+        tagValue:
+          type: string
+          description: The tag's value
+          example: "someUser"
+  ec2KeyName:
+    type: string
+    description: >
+      The name of an Amazon EC2 key-pair that can be used to `SSH` to the master node.
+    example: "myEC2KeyName"
+  applications:
+    type: array
+    description: >
+      A case-insensitive array of applications for Amazon EMR
+      to install and configure when launching the cluster.
+    items:
+      $ref: "./application.yaml"
+  configurations:
+    $ref: "./configurations.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/compute/configurations.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/configurations.yaml
@@ -1,0 +1,18 @@
+type: object
+title: Cluster Configuration Object
+description: >
+  Information about the configurations file that will be used in the EMR cluster.
+  for more information please see [Advanced - Using Bootstrap And Configuration Files](https://help.spot.io/elastigroup-for-aws/services-integrations/elastic-mapreduce/import-an-emr-cluster/advanced/)
+properties:
+  file:
+    type: object
+    description: Location and name of the configurations file that will be used in the EMR cluster.
+    properties:
+      bucket:
+        type: string
+        description: The S3 bucket where the file is stored.
+        example: "emr-test"
+      key:
+        type: string
+        description: The S3 Bucket key of the file.
+        example: "MyFile.json"

--- a/api/services/elastigroup/aws/emr/schemas/compute/coreGroup.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/coreGroup.yaml
@@ -1,0 +1,18 @@
+type: object
+title: Core Group Object
+properties:
+  instanceTypes:
+    $ref: "./group-commons/instanceTypes.yaml"
+  capacity:
+    $ref: "./group-commons/capacity.yaml"
+  lifeCycle:
+    $ref: "./group-commons/lifecycle.yaml"
+    example: "SPOT"
+    description: >
+      **required** only with `clone` strategy
+  ebsConfiguration:
+    $ref: "./group-commons/ebsConfiguration.yaml"
+  configurations:
+    oneOf:
+      - $ref: "./group-commons/jsonConfiguration.yaml"
+      - $ref: "./group-commons/configurations.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/capacity.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/capacity.yaml
@@ -1,0 +1,17 @@
+type: object
+title: Capacity Object
+description: >
+  Capacity specifications for the group: minimum, maximum, and target compute resources
+properties:
+  minimum:
+    type: integer
+    description: Minimum number of instances in group
+    example: 1
+  target:
+    type: integer
+    description: Desired number of instances in group
+    example: 5
+  maximum:
+    type: integer
+    description: Maximum number of instances in group
+    example: 10

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/configurations.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/configurations.yaml
@@ -1,0 +1,17 @@
+type: object
+title: Configurations object
+required:
+  - file
+properties:
+  file:
+    type: object
+    description: Configurations file for the group
+    properties:
+      bucket:
+        type: string
+        description: S3 bucket name of the configurations file for the instance group
+        example: "spot-labs"
+      key:
+        type: string
+        description: S3 key name of the configurations file for the instance group
+        example: "emr_configurations.json"

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/dynamicVolumeSize.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/dynamicVolumeSize.yaml
@@ -1,0 +1,26 @@
+type: object
+title: Dynamic Volume Size Object
+required:
+  - baseSize
+  - resource
+  - sizePerResourceUnit
+description: >
+  Set dynamic volume size properties. **When using this object, you cannot use sizeInGB**. You must use one or the other.
+properties:
+  baseSize:
+    type: integer
+    description: Initial size for volume.
+    example: 50
+  resource:
+    type: string
+    description: >
+      Valid values: "CPU"
+    enum: ["CPU"]
+    example: "CPU"
+  sizePerResourceUnit:
+    type: integer
+    description: >
+      Additional size per resource unit (in GB).
+      Example: if baseSize=50, and sizePerResourceUnit=20, and an instance with 2 CPU is launched
+      - its disk size will be of size 90GB
+    example: 20

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/ebsBlockDeviceConfig.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/ebsBlockDeviceConfig.yaml
@@ -1,0 +1,16 @@
+type: object
+title: Block Device Config Object
+description: Amazon EBS volume specification attached to a cluster instance.
+required:
+  - volumeSpecification
+  - volumesPerInstance
+properties:
+  volumeSpecification:
+    $ref: "./volumeSpecification.yaml"
+  volumesPerInstance:
+    type: integer
+    description: >
+      Number of EBS volumes with a specific volume configuration that will be associated with
+      every instance in the instance group - required if `ebsConfiguration` is defined.
+    example: 1
+

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/ebsConfiguration.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/ebsConfiguration.yaml
@@ -1,0 +1,17 @@
+type: object
+title: EBS Configuration Object
+description: >
+  Information about the EBS configurations that will be attached to each EC2 instance in the group.
+required:
+  - ebsBlockDeviceConfigs
+  - ebsOptimized
+properties:
+  ebsBlockDeviceConfigs:
+    type: array
+    description: An array of Amazon EBS volume specifications attached to a cluster instance.
+    items:
+      $ref: "./ebsBlockDeviceConfig.yaml"
+  ebsOptimized:
+    type: boolean
+    description: Indicates whether an Amazon EBS volume is EBS-optimized.
+    example: true

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/instanceTypes.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/instanceTypes.yaml
@@ -1,0 +1,6 @@
+type: array
+title: Instance Types Array
+description: Instance types to choose from for the group - **required in clone strategy only**
+items:
+  type: string
+example: ["m3.xlarge", "m4.large", "m4.xlarge", "m4.2xlarge"]

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/jsonConfiguration.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/jsonConfiguration.yaml
@@ -1,0 +1,30 @@
+type: object
+title: Json Configuration Object
+description: >
+  EMR cluster configuration in JSON format.
+  You can use `jsonConfiguration` or `file`, but not both.
+  Can be used in `masterGroup`, `coreGroup`, and `taskGroup`.
+requierd:
+  - jsonConfiguration
+properties:
+  jsonConfiguration:
+    type: object
+    properties:
+      classification:
+        type: string
+        description: The grouping within a configuration.
+        example: "mapred-site"
+      properties:
+        type: object
+        description: >
+          Within a configuration classification, a set of properties that represent the settings that
+          you want to change in the configuration file.
+          Duplicates not allowed.
+        example: {"mapred.tasktracker.map.tasks.maximum": 2}
+      configuartions:
+        type: array
+        description: >
+         Array of objects with any keys.
+         This can include additional levels (i.e., nested) of classification, properties, and configurations.
+        items:
+          $ref: "./nestedConfiguration.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/lifeCycle.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/lifeCycle.yaml
@@ -1,0 +1,5 @@
+type: string
+title: LifeCycle Enum
+description: >
+  The life cycle of master group.
+enum: ["SPOT", "ON_DEMAND"]

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/nestedConfiguration.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/nestedConfiguration.yaml
@@ -1,0 +1,14 @@
+type: object
+title: Nested Configuration Object
+properties:
+  classification:
+    type: string
+    description: The grouping within a configuration.
+    example: "hadoop-env"
+  properties:
+    type: object
+    description: >
+      Within a configuration classification, a set of properties that represent the settings that
+      you want to change in the configuration file.
+      Duplicates not allowed.
+    example: {"HADOOP_DATANODE_HEAPSIZE": 2048, "HADOOP_NAMENODE_OPTS": "-XX:GCTimeRatio=19"}

--- a/api/services/elastigroup/aws/emr/schemas/compute/group-commons/volumeSpecification.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/group-commons/volumeSpecification.yaml
@@ -1,0 +1,26 @@
+type: object
+title: Volume Specification Object
+description: >
+  EBS volume specifications such as volume type, IOPS, and size (GiB)
+  that will be requested for the EBS volume attached to an EC2 instance in the cluster - required if `ebsConfiguration` is defined.
+properties:
+  volumeType:
+    type: string
+    description: >
+      The volume type. Volume types supported are `gp2`, `io1`, and `standard` - required if `ebsConfiguration` is defined
+    enum: ["gp2", "io1", "standard"]
+    example: "io1"
+  dynamicVolumeSize:
+    $ref: "./dynamicVolumeSize.yaml"
+  sizeInGB:
+    type: integer
+    description: >
+      The volume size, in gigabytes (GiB).
+      This can be a number from 1 - 1024.
+      **If the volume type is EBS-optimized,
+      the minimum value is 10** - required if `ebsConfiguration` is defined
+    example: 8
+  iops:
+    type: integer
+    description: The number of I/O operations per second (IOPS) that the volume supports.
+    example: 200

--- a/api/services/elastigroup/aws/emr/schemas/compute/instanceGroup.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/instanceGroup.yaml
@@ -1,0 +1,9 @@
+type: object
+title: InstanceGroup Object
+properties:
+  masterGroup:
+    $ref: "./masterGroup.yaml"
+  coreGroup:
+    $ref: "./coreGroup.yaml"
+  taskGroup:
+    $ref: "./taskGroup.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/compute/instanceWeight.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/instanceWeight.yaml
@@ -1,0 +1,17 @@
+type: object
+title: Instance Weight Object
+description: Settings for a single custom weight
+required:
+  - instanceType
+  - weightedCapacity
+properties:
+  instanceType:
+    type: string
+    description: >
+      The instance type to set weight for
+    example: "m4.large"
+  weightedCapacity:
+    type: integer
+    description: >
+      Weight for the chosen instance type.
+    example: 3

--- a/api/services/elastigroup/aws/emr/schemas/compute/masterGroup.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/masterGroup.yaml
@@ -1,0 +1,18 @@
+type: object
+title: Master Group Object
+required:
+  - lifeCycle
+properties:
+  instanceTypes:
+    $ref: "./group-commons/instanceTypes.yaml"
+  target:
+    type: integer
+    description: Number of instances in the master group (always set to 1) - **required in clone strategy only**
+    example: 1
+  lifeCycle:
+    $ref: "./group-commons/lifecycle.yaml"
+    example: "ON_DEMAND"
+  configurations:
+    oneOf:
+      - $ref: "./group-commons/jsonConfiguration.yaml"
+      - $ref: "./group-commons/configurations.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/compute/taskGroup.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/compute/taskGroup.yaml
@@ -1,0 +1,18 @@
+type: object
+title: Task Group Object
+properties:
+  instanceTypes:
+    $ref: "./group-commons/instanceTypes.yaml"
+  capacity:
+    $ref: "./group-commons/capacity.yaml"
+  lifeCycle:
+    $ref: "./group-commons/lifecycle.yaml"
+    example: "SPOT"
+    description: >
+      **required** only with `clone` strategy
+  ebsConfiguration:
+    $ref: "./group-commons/ebsConfiguration.yaml"
+  configurations:
+    oneOf:
+      - $ref: "./group-commons/jsonConfiguration.yaml"
+      - $ref: "./group-commons/configurations.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/costs/mr-scaler-costs.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/costs/mr-scaler-costs.yaml
@@ -1,0 +1,50 @@
+type: object
+title: "MR Scaler Costs Object"
+description: "MR Scaler Costs Object"
+properties:
+  running:
+    type: object
+    description: "Info about the running duration of this MR Scaler"
+    properties:
+      value:
+        type: number
+        format: float
+        description: >
+          The duration this object has been running, denominated in `unit`
+        example: 294.3
+      unit:
+        type: string
+        example: hours
+        description: >
+          Unit of denomination
+  savings:
+    type: object
+    description: "Info about the savings accrued on this MR Scaler"
+    properties:
+      value:
+        type: number
+        format: float
+        description: >
+          The savings accrued during the running duration
+        example: 60.5263
+      unit:
+        type: string
+        example: percentage
+        description: >
+          Unit of denomination
+  costs:
+    type: object
+    description: "Info on the costs of running this MR Scaler"
+    properties:
+      actual:
+        type: number
+        format: float
+        description: >
+          The costs during the running duration
+        example: 8.829
+      potential:
+        type: number
+        format: float
+        description: >
+          The costs that would have been incurred if this MR Scaler wasn't running on Spot
+        example: 22.3668

--- a/api/services/elastigroup/aws/emr/schemas/instance/instance.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/instance/instance.yaml
@@ -1,0 +1,33 @@
+type: object
+title: "EMR Scaler Instance Object"
+description: "An instance in the cluster"
+properties:
+  instanceId:
+    type: string
+    description: "The instance ID"
+    example: "i-asdfjk3989"
+  instanceGroupId:
+    type: string
+    example: "ig-asdfjl2"
+    description: "The instance group ID"
+  instanceGroupRole:
+    type: string
+    example: "MASTER"
+    description: "The instance group role"
+  instanceType:
+    type: string
+    example: "m1.medium"
+    description: "The instance type"
+  availabilityZone:
+    type: string
+    example: "us-east-1a"
+    description: "The availability zone for the instance"
+  status:
+    type: string
+    example: "Running"
+    description: "The instance status"
+  updatedAt:
+    type: string
+    format: date-time
+    example: "2015-08-02T09:11:16.356Z"
+    description: "The last date-time this item was updated"

--- a/api/services/elastigroup/aws/emr/schemas/mrScaler.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/mrScaler.yaml
@@ -1,0 +1,39 @@
+type: object
+title: "MRScaler object Wrapper"
+required:
+  - mrScaler
+properties:
+  mrScaler:
+    required:
+      - name
+      - region
+      - strategy
+    properties:
+      name:
+        type: string
+        description: MRScaler name
+        example: "my MRScaler"
+      description:
+        type: string
+        description: description for the MRScaler
+        example: "this is an MRScaler created with Spot"
+      region:
+        type: string
+        description: The region of the source cluster
+        example: "us-west-2"
+      strategy:
+        $ref: "./strategy.yaml"
+      compute:
+        $ref: "./compute/compute.yaml"
+      cluster:
+        $ref: "./cluster.yaml"
+      scheduling:
+        $ref: "./scheduling/scheduling.yaml"
+      scaling:
+        $ref: "./scaling/scaling.yaml"
+      terminationPolicies:
+        type: array
+        description: >
+          Termination policies for EMR clusters based on CloudWatch Metrics.
+        items:
+          $ref: "./termination-policy/termination-policy.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/put-partial-updates/put-partial-capacity.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/put-partial-updates/put-partial-capacity.yaml
@@ -1,0 +1,28 @@
+type: object
+description: An EMR Scaler Object
+properties:
+  mrScaler:
+    type: object
+    description: "MR Scaler Object - Update Task Capacity"
+    properties:
+      compute:
+        type: object
+        properties:
+          instanceGroups:
+            type: object
+            properties:
+              taskGroup:
+                type: object
+                properties:
+                  capacity:
+                    type: object
+                    properties:
+                      maximum:
+                        type: integer
+                        example: 0
+                      target:
+                        type: integer
+                        example: 0
+                      minimum:
+                        type: integer
+                        example: 0

--- a/api/services/elastigroup/aws/emr/schemas/put-partial-updates/put-partial-dynamic-volume-in-ebs.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/put-partial-updates/put-partial-dynamic-volume-in-ebs.yaml
@@ -1,0 +1,39 @@
+type: object
+description: An EMR Scaler Object
+properties:
+  mrScaler:
+    type: object
+    description: "MR Scaler Object - Update Dynamic Volume Size in EBS Configuration"
+    properties:
+      compute:
+        type: object
+        properties:
+          instanceGroups:
+            type: object
+            properties:
+              taskGroup:
+                type: object
+                properties:
+                  ebsConfiguration:
+                    type: object
+                    properties:
+                      ebsBlockDeviceConfigs:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            volumeSpecification:
+                              type: object
+                              properties:
+                                dynamicVolumeSize:
+                                  type: object
+                                  properties:
+                                    baseSize:
+                                      type: integer
+                                      example: 30
+                                    resource:
+                                      type: string
+                                      example: "CPU"
+                                    sizePerResourceUnit:
+                                      type: integer
+                                      example: 15

--- a/api/services/elastigroup/aws/emr/schemas/scale/scale-down.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scale/scale-down.yaml
@@ -1,0 +1,16 @@
+type: object
+title: An EMR Scale Down Object
+description: "An EMR Scale Down Object"
+properties:
+  modifiedInstanceGroups:
+    type: array
+    description: "The groups modified by this change"
+    items:
+      type: string
+    example: ["ig-2470IUVXLJ652S", "ig-9870IUVXMYYW9"]
+  victimInstances:
+    type: array
+    description: "Terminated instances due to this change"
+    items:
+      type: string
+    example: ["ig-0570LPWAZXBSR3"]

--- a/api/services/elastigroup/aws/emr/schemas/scale/scale-up.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scale/scale-up.yaml
@@ -1,0 +1,16 @@
+type: object
+title: An EMR Scale Up Object
+description: "An EMR Scale Up Object"
+properties:
+  modifiedInstanceGroups:
+    type: array
+    description: "The groups modified by this change"
+    items:
+      type: string
+    example: ["ig-2470IUVXLJ652S", "ig-9870IUVXMYYW9"]
+  newInstanceGroups:
+    type: array
+    description: "Newly launched instances due to this change"
+    items:
+      type: string
+    example: ["ig-0570LPWAZXBSR3"]

--- a/api/services/elastigroup/aws/emr/schemas/scaling/scaling-action-down.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scaling/scaling-action-down.yaml
@@ -1,0 +1,43 @@
+type: object
+title: Scaling Down Action Object
+description: The action to take when scale down is needed.
+properties:
+  type:
+    type: string
+    description: >
+      The type of the action to take when scale down is needed. Valid Values: `adjustment` | `updateCapacity` | `setMaxTarget`
+    enum:
+      - "adjustment"
+      - "updateCapacity"
+      - "setMaxTarget"
+    example: "adjustment"
+  maxTargetCapacity:
+    type: integer
+    description: >
+      Required if using `setMaxTarget` as action type.
+      A number specifying the target capacity needed.
+    example: 1
+  adjustment:
+    type: integer
+    description: >
+      Required if using `adjustment` as action type.
+      The number associated with the specified adjustment type.
+    example: 2
+  target:
+    type: integer
+    description: >
+      Required if using `updateCapacity` as action type and neither `minimum` nor `maximum` are defined.
+      The desired number of instances.
+    example: 2
+  minimum:
+    type: integer
+    description: >
+      Required if using `updateCapacity` as action type and neither `target` nor `maximum` are defined.
+      The lower limit number of instances that you can scale down to.
+    example: 1
+  maximum:
+    type: integer
+    description: >
+      Required if using `updateCapacity` as action type and neither `target` nor `minimum` defined.
+      The upper limit number of instances that you can scale up to.
+    example: 5

--- a/api/services/elastigroup/aws/emr/schemas/scaling/scaling-action-up.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scaling/scaling-action-up.yaml
@@ -1,0 +1,43 @@
+type: object
+title: Scaling up Action Object
+description: The action to take when scale up is needed.
+properties:
+  type:
+    type: string
+    description: >
+      The type of the action to take when scale up is needed. Valid Values: `adjustment` | `updateCapacity` | `setMinTarget`
+    enum:
+      - "adjustment"
+      - "updateCapacity"
+      - "setMinTarget"
+    example: "adjustment"
+  minTargetCapacity:
+    type: integer
+    description: >
+      Required if using `setMinTarget` as action type.
+      A number specifying the target capacity needed.
+    example: 1
+  adjustment:
+    type: integer
+    description: >
+      Required if using `adjustment` as action type.
+      The number associated with the specified adjustment type.
+    example: 2
+  target:
+    type: integer
+    description: >
+      Required if using `updateCapacity` as action type and neither `minimum` nor `maximum` are defined.
+      The desired number of instances.
+    example: 2
+  minimum:
+    type: integer
+    description: >
+      Required if using `updateCapacity` as action type and neither `target` nor `maximum` are defined.
+      The lower limit number of instances that you can scale down to.
+    example: 1
+  maximum:
+    type: integer
+    description: >
+      Required if using `updateCapacity` as action type and neither `target` nor `minimum` defined.
+      The upper limit number of instances that you can scale up to.
+    example: 5

--- a/api/services/elastigroup/aws/emr/schemas/scaling/scaling-down.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scaling/scaling-down.yaml
@@ -1,0 +1,100 @@
+type: object
+title: Scaling Down Object
+description: A scale-down policy
+properties:
+  policyName:
+    type: string
+    description: The Scaling policy name
+    example: "myScaleDownPolicyName"
+  metricName:
+    type: string
+    description: The name of the metric
+    default: "AppsPending"
+    example: "AppsPending"
+  unit:
+    type: string
+    description: The unit for the alarm’s associated metric.
+    example: "count"
+    enum:
+      - "seconds"
+      - "microseconds"
+      - "milliseconds"
+      - "bytes"
+      - "kilobytes"
+      - "megabytes"
+      - "gigabytes"
+      - "terabytes"
+      - "bits"
+      - "kilobits"
+      - "megabits"
+      - "gigabits"
+      - "terabits"
+      - "percent"
+      - "count"
+      - "bytes/second"
+      - "kilobytes/second"
+      - "megabytes/second"
+      - "gigabytes/second"
+      - "terabytes/second"
+      - "bits/second"
+      - "kilobits/second"
+      - "megabits/second"
+      - "gigabits/second"
+      - "terabits/second"
+      - "count/second"
+      - "none"
+  threshold:
+    type: integer
+    description: The value against which the specified statistic is compared.
+    example: 100
+  action:
+    $ref: "./scaling-action-down.yaml"
+  adjustment:
+    type: integer
+    description: >
+      **Required if using `adjustment` as action type**. The number associated with the specified adjustment type.
+    example: 2
+  period:
+    type: integer
+    description: The period in seconds over which the statistic is applied.
+    example: 300
+  evaluationPeriods:
+    type: integer
+    description: The number of periods over which data is compared to the specified threshold
+    example: 1
+  dimensions:
+    type: array
+    description: The dimensions for the alarm’s associated metric.
+    items:
+      type: object
+      description: The dimension for the alarm’s associated metric.
+      properties:
+        name:
+          type: string
+          description: the dimension name
+          example: "JobFlowId"
+  operator:
+    type: string
+    description: >
+      The operator to use in order to determine if the scaling policy is applicable. Valid values: `gt` | `gte` | `lt` | `lte`
+    enum:
+      - "gte"
+      - "lte"
+      - "lt"
+      - "gt"
+    example: "lte"
+  statistic:
+    type: string
+    description: >
+      The metric statistics to return.  Valid Values: `average`, `sum`, `sampleCount`, `maximum`, `minimum`
+    enum:
+      - "average"
+      - "sum"
+      - "sampleCount"
+      - "maximum"
+      - "minimum"
+  namespace:
+    type: string
+    description: The namespace for the alarm’s associated metric.
+    default: "AWS/ElasticMapReduce"
+    example: "AWS/ElasticMapReduce"

--- a/api/services/elastigroup/aws/emr/schemas/scaling/scaling-up.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scaling/scaling-up.yaml
@@ -1,0 +1,100 @@
+type: object
+title: Scaling Up Object
+description: A scale-up policy
+properties:
+  policyName:
+    type: string
+    description: The Scaling policy name
+    example: "myScaleUpPolicyName"
+  metricName:
+    type: string
+    description: The name of the metric
+    default: "AppsPending"
+    example: "AppsPending"
+  unit:
+    type: string
+    description: The unit for the alarm’s associated metric.
+    example: "count"
+    enum:
+      - "seconds"
+      - "microseconds"
+      - "milliseconds"
+      - "bytes"
+      - "kilobytes"
+      - "megabytes"
+      - "gigabytes"
+      - "terabytes"
+      - "bits"
+      - "kilobits"
+      - "megabits"
+      - "gigabits"
+      - "terabits"
+      - "percent"
+      - "count"
+      - "bytes/second"
+      - "kilobytes/second"
+      - "megabytes/second"
+      - "gigabytes/second"
+      - "terabytes/second"
+      - "bits/second"
+      - "kilobits/second"
+      - "megabits/second"
+      - "gigabits/second"
+      - "terabits/second"
+      - "count/second"
+      - "none"
+  threshold:
+    type: integer
+    description: The value against which the specified statistic is compared.
+    example: 100
+  action:
+    $ref: "./scaling-action-up.yaml"
+  adjustment:
+    type: integer
+    description: >
+      **Required if using `adjustment` as action type**. The number associated with the specified adjustment type.
+    example: 2
+  period:
+    type: integer
+    description: The period in seconds over which the statistic is applied.
+    example: 300
+  evaluationPeriods:
+    type: integer
+    description: The number of periods over which data is compared to the specified threshold
+    example: 1
+  dimensions:
+    type: array
+    description: The dimensions for the alarm’s associated metric.
+    items:
+      type: object
+      description: The dimension for the alarm’s associated metric.
+      properties:
+        name:
+          type: string
+          description: the dimension name
+          example: "JobFlowId"
+  operator:
+    type: string
+    description: >
+     The operator to use in order to determine if the scaling policy is applicable. Valid values: `gt` | `gte` | `lt` | `lte`
+    enum:
+      - "gte"
+      - "lte"
+      - "lt"
+      - "gt"
+    example: "gte"
+  statistic:
+    type: string
+    description: >
+      The metric statistics to return.  Valid Values: `average`, `sum`, `sampleCount`, `maximum`, `minimum`
+    enum:
+      - "average"
+      - "sum"
+      - "sampleCount"
+      - "maximum"
+      - "minimum"
+  namespace:
+    type: string
+    description: The namespace for the alarm’s associated metric.
+    default: "AWS/ElasticMapReduce"
+    example: "AWS/ElasticMapReduce"

--- a/api/services/elastigroup/aws/emr/schemas/scaling/scaling.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scaling/scaling.yaml
@@ -1,0 +1,8 @@
+type: object
+title: Scaling Object
+description: Set scaling polices.
+properties:
+  up:
+    $ref: "./scaling-up.yaml"
+  down:
+    $ref: "./scaling-down.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/scheduling/scheduling.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scheduling/scheduling.yaml
@@ -1,0 +1,9 @@
+type: object
+title: Scheduling Object
+description: Schedule tasks to execute on the Elastigroup.
+properties:
+  tasks:
+    type: array
+    description: An array of scheduled tasks.
+    items:
+      $ref: "./task.yaml"

--- a/api/services/elastigroup/aws/emr/schemas/scheduling/task.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/scheduling/task.yaml
@@ -1,0 +1,37 @@
+type: object
+title: Task Object
+description: A scheduled task
+properties:
+  isEnabled:
+    type: boolean
+    description: Enable/Disable the specified scheduling task.
+    example: true
+    default: true
+  instanceGroupType:
+    type: string
+    description: >
+     Select the EMR instance groups to execute the scheduled task on. Valid values: `task`
+    example: "task"
+    enum: ["task"]
+  taskType:
+    type: string
+    description: >
+      The type of task to be scheduled. Valid values: `setCapacity`
+    example: "setCapacity"
+    enum: ["setCapacity"]
+  cronExpression:
+    type: string
+    description: A valid Cron expression
+    example: "* 8 * 10 *"
+  targetCapacity:
+    type: integer
+    description: Set a new target capacity for the Elastigroup.
+    example: 2
+  minCapacity:
+    type: integer
+    description: Set a new minimum capacity for the Elastigroup.
+    example: 2
+  maxCapacity:
+    type: integer
+    description: Set a new maximum capacity for the Elastigroup.
+    example: 2

--- a/api/services/elastigroup/aws/emr/schemas/strategy.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/strategy.yaml
@@ -1,0 +1,64 @@
+type: object
+title: "Strategy Object"
+description: >
+  The strategy for creating the group.
+  At least one of `wrapping`, `cloning`, or `new` is required.
+properties:
+  wrapping:
+    type: object
+    description: >
+      Required unless either of `strategy.cloning` or `strategy.new` is specified.
+      In wrap mode, MRScaler will manage an existing cluster and will scale up/down cluster task groups only.
+      MRScaler will manage only instance groups that were created by Spot.
+    properties:
+      sourceClusterId:
+        type: string
+        example: "c-1234"
+  new:
+    type: object
+    description: >
+      Required unless `strategy.wrapping` or `strategy.cloning` is specified.
+      In new mode, MRScaler will create a new cluster with the parameters specified in the request.
+    properties:
+      releaseLabel:
+        type: string
+        example: "emr-5.17.0"
+      numberOfRetries:
+        type: integer
+        example: 5
+  cloning:
+    type: object
+    description: >
+      Required unless either of `strategy.wrapping` or `strategy.new` is specified.
+      In clone mode, MRScaler will create a new cluster that will be copied from the origin cluster.
+      MRScaler will manage the entire cluster (the origin cluster will not be affected)
+    properties:
+      originClusterId:
+        type: string
+        description: The ID of the cluster to clone
+        example: "j-38EE27G2QY02I"
+      includeSteps:
+        type: boolean
+        description: Include cloning of steps from the original cluster
+        example: false
+      numberOfRetries:
+        type: integer
+        description: number of times to retry if provisioning timeout is exceeded
+        example: 5
+  provisioningTimeout:
+    type: object
+    description: >
+      EMR clusters occasionally get stuck in provisioning status due to unhealthy clusters, slowness or other issues.
+      In such cases, a timeout can be used to automatically terminate the cluster after the defined period of time.
+    properties:
+      timeout:
+        type: integer
+        description: >
+          Time (minutes) after which the cluster is automatically terminated if it's still in provisioning status.
+        example: 15
+      timeoutAction:
+        type: string
+        enum: ["terminate", "terminateAndRetry"]
+        description: >
+          Desired action if the timeout is exceeded. Currently `terminate` and `terminateAndRetry` are supported.
+        example: "terminate"

--- a/api/services/elastigroup/aws/emr/schemas/termination-policy/termination-policy-statement.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/termination-policy/termination-policy-statement.yaml
@@ -1,0 +1,84 @@
+type: object
+title: Termination Statement Object
+description: A termination statement to execute
+required:
+  - namespace
+  - metricName
+  - threshold
+properties:
+  namespace:
+    type: string
+    description: >
+      **Must be `AWS/ElasticMapReduce`"
+    example: "AWS/ElasticMapReduce"
+  metricName:
+    type: string
+    description: The name of the metric in CloudWatch which the statement will be based on.
+    example: "AppsRunning"
+  statistic:
+    type: string
+    description: The aggregation method of the given metric
+    enum:
+      - "average"
+      - "sum"
+      - "sampleCount"
+      - "maximum"
+      - "minimum"
+    default: "sum"
+  unit:
+    type: string
+    description: The unit for a given metric.
+    example: "count"
+    enum:
+      - "seconds"
+      - "microseconds"
+      - "milliseconds"
+      - "bytes"
+      - "kilobytes"
+      - "megabytes"
+      - "gigabytes"
+      - "terabytes"
+      - "bits"
+      - "kilobits"
+      - "megabits"
+      - "gigabits"
+      - "terabits"
+      - "percent"
+      - "count"
+      - "bytes/second"
+      - "kilobytes/second"
+      - "megabytes/second"
+      - "gigabytes/second"
+      - "terabytes/second"
+      - "bits/second"
+      - "kilobits/second"
+      - "megabits/second"
+      - "gigabits/second"
+      - "terabits/second"
+      - "count/second"
+      - "none"
+    default: "count"
+  threshold:
+    type: number
+    format: double
+    description: The value that the specified statistic is compared to.
+    example: 2.0
+  period:
+    type: integer
+    description: The period in seconds over which the statistic is applied.
+    example: 300
+  evaluationPeriods:
+    type: integer
+    description: The number of periods over which data is compared to the specified threshold
+    example: 1
+  operator:
+    type: string
+    description: >
+      The operator to use in order to determine if the scaling policy is applicable. Valid values: `gt` | `gte` | `lt` | `lte`
+    enum:
+      - "gte"
+      - "lte"
+      - "lt"
+      - "gt"
+    example: "gte"
+    default: "gte"

--- a/api/services/elastigroup/aws/emr/schemas/termination-policy/termination-policy.yaml
+++ b/api/services/elastigroup/aws/emr/schemas/termination-policy/termination-policy.yaml
@@ -1,0 +1,9 @@
+type: object
+title: Termination Policy Object
+description: A termination policy for EMR clusters based on CloudWatch Metrics.
+properties:
+  statements:
+    type: array
+    description: Array of termination statements to execute
+    items:
+      $ref: "./termination-policy-statement.yaml"

--- a/api/spotinst.yaml
+++ b/api/spotinst.yaml
@@ -66,6 +66,20 @@ paths:
     $ref: 'services/elastigroup/aws/paths/instance-lock.yaml'
   /aws/ec2/instance/{instanceId}/unlock:
     $ref: 'services/elastigroup/aws/paths/instance-unlock.yaml'
+  /aws/emr/mrScaler:
+    $ref: 'services/elastigroup/aws/emr/paths/mr-scalers.yaml'
+  /aws/emr/mrScaler/{mrScalerId}:
+    $ref: 'services/elastigroup/aws/emr/paths/mr-scaler.yaml'
+  /aws/emr/mrScaler/{mrScalerId}/instance:
+    $ref: 'services/elastigroup/aws/emr/paths/mr-scaler-instance.yaml'
+  /aws/emr/mrScaler/{mrScalerId}/scale/up:
+    $ref: 'services/elastigroup/aws/emr/paths/mr-scaler-scale-up.yaml'
+  /aws/emr/mrScaler/{mrScalerId}/scale/down:
+    $ref: 'services/elastigroup/aws/emr/paths/mr-scaler-scale-down.yaml'
+  /aws/emr/mrScaler/{mrScalerId}/scale/cluster:
+    $ref: 'services/elastigroup/aws/emr/paths/mr-scaler-cluster.yaml'
+  /aws/emr/mrScaler/{mrScalerId}/scale/costs:
+    $ref: 'services/elastigroup/aws/emr/paths/mr-scaler-costs.yaml'
   /compute/azure/group:
     $ref: 'services/elastigroup/azure/paths/groups.yaml'
   /compute/azure/group/{groupId}:


### PR DESCRIPTION
This PR adds support for all 10  AWS EMR routes:

- Update
- List MR Scaler
- Delete MR Scaler
- List Instances
- MR Scaler Clusters
- MR Scaler Costs
- Scale Up
- Scale Down
- Create
- List All MR Scalers

Notes:

- Once the repo becomes less volatile – without a lot of conflicting PRs – it would be good to extract the schema `createdAtUpdatedAt.yaml` as a top-level `commons/schema`. This one allows us to attach `createdAt` & `updatedAt` to objects in the response:  some responses omit/include those. It's currently duplicated in:
    - `api/services/elastigroup/aws/emr/schemas/commons`
    - `api/services/elastigroup/gcp/schemas/commons`