### PR TITLE
Adding availabilityZones

### DIFF
--- a/api/services/ocean/gke/schemas/ocean-compute.yaml
+++ b/api/services/ocean/gke/schemas/ocean-compute.yaml
@@ -4,13 +4,14 @@ required:
   - subnetname
   - launchSpecification
   - networkInterfaces
+  - availabilityZones
 properties:
   networkInterfaces:
-    type: object
+    type: array
     description: >
       Settings for network interfaces
     required:
-      - accessConfig
+      - accessConfigs
       - network
     properties:
       network:
@@ -69,6 +70,10 @@ properties:
     type: string
     description: Subnet identifier for the Ocean cluster
     example: default
+  availabilityZones:
+    type: array
+    description: Availability zone/s used by the Ocean cluster.
+    example: us-west1-a
   instanceTypes:
     type: object
     description: The type of instances that may or may not be a part of the Ocean cluster.


### PR DESCRIPTION
Missing required availabilityZones. 

In addition, `networkInterfaces` is an array of objects. We should correctly show this. Im not sure how to properly show this with openapi property fields. 

Without it I get the following response:
`   "response": {
        "status": {
            "code": 400,
            "message": "Bad Request"
        },
        "errors": [
            {
                "code": "ValidationError",
                "message": "\"availabilityZones\" is required",
                "field": "body:cluster.compute.availabilityZones"
            }
        ]
    }`