### PR TITLE
AWSEG_16921_Ability_to_tag_resources_per_specific_group

### DIFF
--- a/api/services/elastigroup/aws/schemas/elastigroup-compute.yaml
+++ b/api/services/elastigroup/aws/schemas/elastigroup-compute.yaml
@@ -383,3 +383,43 @@ properties:
               description: |
                 The tag's value
               example: "John Doe"
+      resourceTagSpecification:
+        type: object
+        description: Optional field. User will specified which resources should be tagged with group tags.
+        properties:
+          volumes:
+            type: object
+            description: Optional field. Tag specification for Volume resources.
+            properties:
+              shouldTag:
+                type: boolean
+                description: Optional field. Volume resources will be tagged with group tags.
+                default: false
+                example: false
+          snapshots:
+            type: object
+            description: Optional field. Tag specification for Snapshot resources.
+            properties:
+              shouldTag:
+                type: boolean
+                description: Optional field. Snapshot resources will be tagged with group tags.
+                default: true
+                example: true
+          enis:
+            type: object
+            description: Optional field. Tag specification for ENI resources.
+            properties:
+              shouldTag:
+                type: boolean
+                description: Optional field. ENI resources will be tagged with group tags.
+                default: false
+                example: false
+          amis:
+            type: object
+            description: Optional field. Tag specification for AMI resources.
+            properties:
+              shouldTag:
+                type: boolean
+                description: Optional field. AMI resources will be tagged with group tags.
+                default: true
+                example: true

--- a/api/services/elastigroup/aws/schemas/elastigroupCreate.yaml
+++ b/api/services/elastigroup/aws/schemas/elastigroupCreate.yaml
@@ -589,6 +589,46 @@ properties:
                       description: |
                         The tag's value
                       example: "John Doe"
+              resourceTagSpecification:
+                type: object
+                description: Optional field. User will specified which resources should be tagged with group tags.
+                properties:
+                  volumes:
+                    type: object
+                    description: Optional field. Tag specification for Volume resources.
+                    properties:
+                      shouldTag:
+                        type: boolean
+                        description: Optional field. Volume resources will be tagged with group tags.
+                        default: false
+                        example: false
+                  snapshots:
+                    type: object
+                    description: Optional field. Tag specification for Snapshot resources.
+                    properties:
+                      shouldTag:
+                        type: boolean
+                        description: Optional field. Snapshot resources will be tagged with group tags.
+                        default: true
+                        example: true
+                  enis:
+                    type: object
+                    description: Optional field. Tag specification for ENI resources.
+                    properties:
+                      shouldTag:
+                        type: boolean
+                        description: Optional field. ENI resources will be tagged with group tags.
+                        default: false
+                        example: false
+                  amis:
+                    type: object
+                    description: Optional field. Tag specification for AMI resources.
+                    properties:
+                      shouldTag:
+                        type: boolean
+                        description: Optional field. AMI resources will be tagged with group tags.
+                        default: true
+                        example: true
               metadataOptions:
                 title: Metadata Options
                 type: object


### PR DESCRIPTION
[src] add api documentation for ElastiGroup create/update for resourcesToTag parameter