### PR TITLE
- ocean gke changes (service account add)

### DIFF
--- a/api/services/ocean/aws/paths/clusters-launchSpec.yaml
+++ b/api/services/ocean/aws/paths/clusters-launchSpec.yaml
@@ -1,8 +1,8 @@
 summary: Ocean for AWS
 post:
-  summary: "Create Launch Spec"
+  summary: "Create Virtual Node Group"
   description: >
-    Create a Launch Spec.
+    Create a Virtual Node Group.
   operationId: "OceanAWSLaunchSpecCreate"
   tags:
     - "Ocean AWS"
@@ -23,13 +23,13 @@ post:
       description: "Bad Request"
 
 get:
-  summary: "List Launch Specs"
+  summary: "List Virtual Node Groups"
   operationId: "OceanAWSLaunchSpecList"
   tags:
     - "Ocean AWS"
   parameters:
     - $ref: "../../../../commons/parameters/accountId.yaml"
-    - $ref: "../../commons/parameters/oceanId.yaml"
+    - $ref: "../../commons/parameters/oceanId-query.yaml"
   responses:
     200:
       $ref: "../responses/oceanLaunchSpec.yaml"

--- a/api/services/ocean/commons/parameters/initialNodes.yaml
+++ b/api/services/ocean/commons/parameters/initialNodes.yaml
@@ -3,7 +3,7 @@ name: "initialNodes"
 example: 1
 default: null
 description: >
-  When set to an integer greater than 0, a corresponding amount of nodes will be launched from the created launch spec
+  When set to an integer greater than 0, a corresponding amount of nodes will be launched from the created virtual node group.
 schema:
   type: integer
 required: false

--- a/api/services/ocean/commons/parameters/oceanId-query.yaml
+++ b/api/services/ocean/commons/parameters/oceanId-query.yaml
@@ -1,0 +1,8 @@
+in: query
+name: "OCEAN_ID"
+schema:
+  type: "string"
+required: true
+example: o-abcd1234
+description: >
+  The ID of the Ocean cluster.

--- a/api/services/ocean/gke/schemas/ocean-compute.yaml
+++ b/api/services/ocean/gke/schemas/ocean-compute.yaml
@@ -133,6 +133,8 @@ properties:
       serviceAccount:
         type: string
         example: 265168459660-compute@developer.gserviceaccount.com
+        description: >
+          The service account used by applications running on the VM to call GCP APIs.
       labels:
         type: array
         description: >

--- a/api/services/ocean/gke/schemas/oceanClusterLaunchSpec.yaml
+++ b/api/services/ocean/gke/schemas/oceanClusterLaunchSpec.yaml
@@ -22,6 +22,11 @@ properties:
         example: "https://www.googleapis.com/compute/v1/projects/gke-node-images/global/images/container-v1-3-v20160517"
         description: >
           Set image URL. Can be null
+      serviceAccount:
+        type: string
+        example: 265168459660-compute@developer.gserviceaccount.com
+        description: >
+          The service account used by applications running on the VM to call GCP APIs.
       rootVolumeSize:
         type: integer
         description: Set root volume size (in GB)

--- a/api/services/ocean/gke/schemas/oceanClusterLaunchSpecUpdate.yaml
+++ b/api/services/ocean/gke/schemas/oceanClusterLaunchSpecUpdate.yaml
@@ -16,6 +16,11 @@ properties:
         example: "lp_name"
         description: >
           Set name for the launch spec
+      serviceAccount:
+        type: string
+        example: 265168459660-compute@developer.gserviceaccount.com
+        description: >
+          The service account used by applications running on the VM to call GCP APIs.
       sourceImage:
         type: string
         example: "https://www.googleapis.com/compute/v1/projects/gke-node-images/global/images/container-v1-3-v20160517"


### PR DESCRIPTION
- rename launch spec to VNG in Ocean k8s AWS relevant routes
- added oceanId**-query** param
- added service account in Ocean GKE LS object 
- added description for Ocean GKE service account