### PR TITLE
Document instance selector and vngId filter for Ocean Spark applications

### DIFF
--- a/api/services/ocean/spark/schemas/oceanSparkApplicationSpec.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkApplicationSpec.yaml
@@ -479,8 +479,10 @@ components:
         image:
           title: Image
           type: string
-        instanceType:
-          title: Instancetype
+        instanceSelector:
+          title: InstanceSelector
+          description: 'The name of an instance family (like "i3" or "m5d"),
+            or of a specficic instance type (like "i3.large" or "m5d.xlarge") to target'
           type: string
         javaOptions:
           title: Javaoptions
@@ -514,6 +516,13 @@ components:
           items:
             $ref: '#/components/schemas/Toleration'
           title: Tolerations
+          type: array
+        vngIds:
+          items:
+            type: string
+          title: Vngids
+          description: 'An optional list of Virtual Node Group identifiers (like ["ols-d1d766b9"])
+            on which the pod can be run. If omitted, the pod can be run on any VNG.'
           type: array
         volumeMounts:
           items:
@@ -585,8 +594,10 @@ components:
         image:
           title: Image
           type: string
-        instanceType:
-          title: Instancetype
+        instanceSelector:
+          title: InstanceSelector
+          description: 'The name of an instance family (like "i3" or "m5d"),
+            or of a specficic instance type (like "i3.large" or "m5d.xlarge") to target'
           type: string
         instances:
           title: Instances
@@ -622,6 +633,12 @@ components:
             $ref: '#/components/schemas/Toleration'
           title: Tolerations
           type: array
+        vngIds:
+          items:
+            type: string
+          title: Vngids
+          description: 'An optional list of Virtual Node Group identifiers (like ["ols-d1d766b9"])
+            on which the pod can be run. If omitted, the pod can be run on any VNG.'
         volumeMounts:
           items:
             $ref: '#/components/schemas/VolumeMount'

--- a/api/services/ocean/spark/schemas/oceanSparkApplicationSpec.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkApplicationSpec.yaml
@@ -480,10 +480,7 @@ components:
           title: Image
           type: string
         instanceSelector:
-          title: InstanceSelector
-          description: 'The name of an instance family (like "i3" or "m5d"),
-            or of a specficic instance type (like "i3.large" or "m5d.xlarge") to target'
-          type: string
+          $ref: '#/components/schemas/InstanceSelector'
         javaOptions:
           title: Javaoptions
           type: string
@@ -518,12 +515,7 @@ components:
           title: Tolerations
           type: array
         vngIds:
-          items:
-            type: string
-          title: Vngids
-          description: 'An optional list of Virtual Node Group identifiers (like ["ols-d1d766b9"])
-            on which the pod can be run. If omitted, the pod can be run on any VNG.'
-          type: array
+          $ref: '#/components/schemas/VngIds'
         volumeMounts:
           items:
             $ref: '#/components/schemas/VolumeMount'
@@ -595,10 +587,7 @@ components:
           title: Image
           type: string
         instanceSelector:
-          title: InstanceSelector
-          description: 'The name of an instance family (like "i3" or "m5d"),
-            or of a specficic instance type (like "i3.large" or "m5d.xlarge") to target'
-          type: string
+          $ref: '#/components/schemas/InstanceSelector'
         instances:
           title: Instances
           type: integer
@@ -634,11 +623,7 @@ components:
           title: Tolerations
           type: array
         vngIds:
-          items:
-            type: string
-          title: Vngids
-          description: 'An optional list of Virtual Node Group identifiers (like ["ols-d1d766b9"])
-            on which the pod can be run. If omitted, the pod can be run on any VNG.'
+          $ref: '#/components/schemas/VngIds'
         volumeMounts:
           items:
             $ref: '#/components/schemas/VolumeMount'
@@ -828,6 +813,11 @@ components:
       - path
       title: HostPathVolumeSource
       type: object
+    InstanceSelector:
+      title: InstanceSelector
+      description: 'The name of an instance family (like "i3" or "m5d"),
+        or of a specific instance type (like "i3.large" or "m5d.xlarge") to target'
+      type: string
     ISCSIVolumeSource:
       properties:
         chapAuthDiscovery:
@@ -1832,6 +1822,12 @@ components:
           type: string
       title: Toleration
       type: object
+    VngIds:
+      items:
+        type: string
+      title: Vngids
+      description: 'An optional list of Virtual Node Group identifiers (like ["ols-d1d766b9"])
+        on which the pod can be run. If omitted, the pod can be run on any VNG.'
     Volume:
       properties:
         awsElasticBlockStore:


### PR DESCRIPTION
# Product Brief / API Discussion document
https://spotinst.atlassian.net/wiki/spaces/BD/pages/2134540299/Pod+Sizing+and+Instance+Selection+API+-+Product+Brief


This PR adds two fields to our Ocean Spark API, in the Driver and Executor specs of Spark applications.

## 1. instanceSelector
This optional field lets users target an instance family (like "i3", "m5", "m5d"). For example if you specify "i3" on the instanceSelector of the ExecutorSpec, then your Spark executors will be launched on nodes of the i3 family (i3.large, i3.xlarge, i3.2xlarge, ...).

The actual mix of instances will be decided by Ocean based on spot market dynamics. Users can also target a specific instance type, like "m5d.2xlarge" using the same field, though most users shouldn't need this. 

Note that in the [API brief](https://spotinst.atlassian.net/wiki/spaces/BD/pages/2134540299/Pod+Sizing+and+Instance+Selection+API+-+Product+Brief) we also plan to add a boolean flag **allowSimilarInstances**. When enabled, this means that in addition to the targeted instance family, we will allow other similar families. 
For example if you select i3 we will also allow r5d. If you select m5, we will also allow m4.
The field will be added at a later stage, after we validate the initial API with customers.

## 2. vngIds
This optional field lets users target a specific VNG for their driver/executors. If users do not set it, there is no constraint, but the backend will still fill up this field after figuring out which VNGs are a good fit.

See this section of the document: https://spotinst.atlassian.net/wiki/spaces/BD/pages/2134540299/Pod+Sizing+and+Instance+Selection+API+-+Product+Brief

Note that the notion of a "VNG dedicated to Ocean Spark" is not implemented yet, but must be implemented soon as it's a requirement to make Ocean Spark pricing work alongside Ocean regular pricing (see the doc).