### PR TITLE
[spark] fix kill API endpoint path

### DIFF
--- a/api/services/ocean/spark/paths/clusterApplication.yaml
+++ b/api/services/ocean/spark/paths/clusterApplication.yaml
@@ -16,3 +16,21 @@ get:
       $ref: "../responses/applications.yaml"
     400:
       description: "Bad Request"
+
+delete:
+  summary: "Delete or kill an Application"
+  description: >
+    For pending Spark applications, the creation request is canceled.
+    For running Spark applications, the application is forcibly interrupted.
+  operationId: "OceanSparkClusterApplicationDelete"
+  tags:
+    - "Ocean Spark"
+  parameters:
+    - $ref: "../../../../commons/parameters/nonRequiredAccountId.yaml"
+    - $ref: "../parameters/path/oceanSparkClusterId.yaml"
+    - $ref: "../parameters/path/oceanSparkApplicationId.yaml"
+  responses:
+    204:
+      description: "Application deleted"
+    400:
+      description: "Bad Request"

--- a/api/services/ocean/spark/paths/clusterApplications.yaml
+++ b/api/services/ocean/spark/paths/clusterApplications.yaml
@@ -77,20 +77,3 @@ post:
       $ref: "../responses/applications.yaml"
     400:
       description: "Bad Request"
-
-delete:
-  summary: "Delete or kill an Application"
-  description: >
-    For pending Spark applications, the creation request is canceled.
-    For running Spark applications, the application is forcibly interrupted.
-  operationId: "OceanSparkClusterApplicationDelete"
-  tags:
-    - "Ocean Spark"
-  parameters:
-    - $ref: "../../../../commons/parameters/nonRequiredAccountId.yaml"
-    - $ref: "../parameters/path/oceanSparkClusterId.yaml"
-  responses:
-    204:
-      description: "Application deleted"
-    400:
-      description: "Bad Request"


### PR DESCRIPTION
The endpoint was
```
DELETE ocean/spark/cluster/{clusterId}/app
```
when it should be
```
DELETE ocean/spark/cluster/{clusterId}/app/{applicationId}
```