### PR TITLE
Ocean spark app api model

### DIFF
--- a/api/services/ocean/spark/paths/clusterApplication.yaml
+++ b/api/services/ocean/spark/paths/clusterApplication.yaml
@@ -30,7 +30,7 @@ delete:
     - $ref: "../parameters/path/oceanSparkClusterId.yaml"
     - $ref: "../parameters/path/oceanSparkApplicationId.yaml"
   responses:
-    204:
-      description: "Application deleted"
+    200:
+      $ref: "../responses/killedApplication.yaml"
     400:
       description: "Bad Request"

--- a/api/services/ocean/spark/paths/clusterApplication.yaml
+++ b/api/services/ocean/spark/paths/clusterApplication.yaml
@@ -13,7 +13,7 @@ get:
     - $ref: "../parameters/path/oceanSparkApplicationId.yaml"
   responses:
     200:
-      $ref: "../responses/applications.yaml"
+      $ref: "../responses/detailedApplication.yaml"
     400:
       description: "Bad Request"
 

--- a/api/services/ocean/spark/paths/clusterApplications.yaml
+++ b/api/services/ocean/spark/paths/clusterApplications.yaml
@@ -74,6 +74,6 @@ post:
               $ref: "../schemas/oceanSparkConfigTemplateId.yaml"
   responses:
     200:
-      $ref: "../responses/applications.yaml"
+      $ref: "../responses/submittedApplication.yaml"
     400:
       description: "Bad Request"

--- a/api/services/ocean/spark/responses/detailedApplication.yaml
+++ b/api/services/ocean/spark/responses/detailedApplication.yaml
@@ -1,0 +1,17 @@
+description: A Spark application
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../commons/schemas/responseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              description: >
+                response body
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/oceanDetailedSparkApplication.yaml"

--- a/api/services/ocean/spark/responses/killedApplication.yaml
+++ b/api/services/ocean/spark/responses/killedApplication.yaml
@@ -1,0 +1,17 @@
+description: A killed Spark application
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../commons/schemas/responseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              description: >
+                response body
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/oceanKilledSparkApplication.yaml"

--- a/api/services/ocean/spark/responses/paginatedApplications.yaml
+++ b/api/services/ocean/spark/responses/paginatedApplications.yaml
@@ -21,4 +21,4 @@ content:
                         page:
                           type: array
                           items:
-                            $ref: "../schemas/oceanSparkApplication.yaml"
+                            $ref: "../schemas/oceanSparkApplicationPageItem.yaml"

--- a/api/services/ocean/spark/responses/submittedApplication.yaml
+++ b/api/services/ocean/spark/responses/submittedApplication.yaml
@@ -1,0 +1,17 @@
+description: A Spark application just submitted
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: "../../../../commons/schemas/responseItemWrapper.yaml"
+        - type: object
+          properties:
+            response:
+              type: object
+              description: >
+                response body
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../schemas/oceanSubmittedSparkApplication.yaml"

--- a/api/services/ocean/spark/schemas/oceanDetailedSparkApplication.yaml
+++ b/api/services/ocean/spark/schemas/oceanDetailedSparkApplication.yaml
@@ -1,0 +1,77 @@
+type: object
+required:
+- id
+- displayName
+- accountId
+- organizationId
+- userId
+- clusterId
+- controllerClusterId
+- appState
+- submissionSource
+- createdAt
+- updatedAt
+allOf:
+- $ref: "../../../../commons/schemas/createdAtUpdatedAt.yaml"
+- type: object
+  description: >
+    The description of a Spark application
+  properties:
+    id:
+      $ref: "oceanSparkApplicationId.yaml"
+    displayName:
+      $ref: "oceanSparkApplicationDisplayName.yaml"
+    userId:
+      $ref: "userId.yaml"
+    clusterId:
+      $ref: "oceanSparkClusterId.yaml"
+    controllerClusterId:
+      $ref: "controllerClusterId.yaml"
+    appState:
+      $ref: "oceanSparkApplicationState.yaml"
+    submissionSource:
+      $ref: "oceanSparkApplicationSubmissionSource.yaml"
+    job:
+      type: object
+      description: >
+        The job to which the application belongs.
+        A job is collection of Spark applications, typically a workload run on a schedule.
+      required:
+        - id
+        - displayName
+      properties:
+        id:
+          $ref: oceanSparkJobId.yaml
+        displayName:
+          $ref: oceanSparkJobDisplayName.yaml
+    config:
+      $ref: "oceanSparkApplicationSpec.yaml"
+    startedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application started running (the app state becomes RUNNING).
+        This is not the time when the application launch was requested (this is `createdAt`).
+      example: "2021-11-18T17:09:37+00:00"
+    endedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application terminated.
+      example: "2021-11-18T17:09:37+00:00"
+    liveLog:
+      type: object
+      description: API pointers to endpoints serving logs and events related to the Spark application
+      properties:
+        logsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving the live driver logs
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/logs/live
+        kubeEventsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving a stream of Kubernetes events
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/kubeEvents/live
+    metrics:
+      $ref: "./oceanSparkApplicationMetrics.yaml"

--- a/api/services/ocean/spark/schemas/oceanKilledSparkApplication.yaml
+++ b/api/services/ocean/spark/schemas/oceanKilledSparkApplication.yaml
@@ -1,0 +1,60 @@
+type: object
+required:
+- id
+- displayName
+- accountId
+- organizationId
+- userId
+- clusterId
+- controllerClusterId
+- appState
+- submissionSource
+- createdAt
+- updatedAt
+allOf:
+- $ref: "../../../../commons/schemas/createdAtUpdatedAt.yaml"
+- type: object
+  description: >
+    The description of a Spark application
+  properties:
+    id:
+      $ref: "oceanSparkApplicationId.yaml"
+    displayName:
+      $ref: "oceanSparkApplicationDisplayName.yaml"
+    userId:
+      $ref: "userId.yaml"
+    clusterId:
+      $ref: "oceanSparkClusterId.yaml"
+    controllerClusterId:
+      $ref: "controllerClusterId.yaml"
+    appState:
+      $ref: "oceanSparkApplicationState.yaml"
+    submissionSource:
+      $ref: "oceanSparkApplicationSubmissionSource.yaml"
+    startedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application started running (the app state becomes RUNNING).
+        This is not the time when the application launch was requested (this is `createdAt`).
+      example: "2021-11-18T17:09:37+00:00"
+    endedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application terminated.
+      example: "2021-11-18T17:09:37+00:00"
+    liveLog:
+      type: object
+      description: API pointers to endpoints serving logs and events related to the Spark application
+      properties:
+        logsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving the live driver logs
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/logs/live
+        kubeEventsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving a stream of Kubernetes events
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/kubeEvents/live

--- a/api/services/ocean/spark/schemas/oceanSparkApplicationPageItem.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkApplicationPageItem.yaml
@@ -1,0 +1,75 @@
+type: object
+required:
+- id
+- displayName
+- accountId
+- organizationId
+- userId
+- clusterId
+- controllerClusterId
+- appState
+- submissionSource
+- createdAt
+- updatedAt
+allOf:
+- $ref: "../../../../commons/schemas/createdAtUpdatedAt.yaml"
+- type: object
+  description: >
+    The description of a Spark application
+  properties:
+    id:
+      $ref: "oceanSparkApplicationId.yaml"
+    displayName:
+      $ref: "oceanSparkApplicationDisplayName.yaml"
+    userId:
+      $ref: "userId.yaml"
+    clusterId:
+      $ref: "oceanSparkClusterId.yaml"
+    controllerClusterId:
+      $ref: "controllerClusterId.yaml"
+    appState:
+      $ref: "oceanSparkApplicationState.yaml"
+    submissionSource:
+      $ref: "oceanSparkApplicationSubmissionSource.yaml"
+    job:
+      type: object
+      description: >
+        The job to which the application belongs.
+        A job is collection of Spark applications, typically a workload run on a schedule.
+      required:
+        - id
+        - displayName
+      properties:
+        id:
+          $ref: oceanSparkJobId.yaml
+        displayName:
+          $ref: oceanSparkJobDisplayName.yaml
+    startedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application started running (the app state becomes RUNNING).
+        This is not the time when the application launch was requested (this is `createdAt`).
+      example: "2021-11-18T17:09:37+00:00"
+    endedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application terminated.
+      example: "2021-11-18T17:09:37+00:00"
+    liveLog:
+      type: object
+      description: API pointers to endpoints serving logs and events related to the Spark application
+      properties:
+        logsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving the live driver logs
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/logs/live
+        kubeEventsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving a stream of Kubernetes events
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/kubeEvents/live
+    metrics:
+      $ref: "./oceanSparkApplicationMetrics.yaml"

--- a/api/services/ocean/spark/schemas/oceanSubmittedSparkApplication.yaml
+++ b/api/services/ocean/spark/schemas/oceanSubmittedSparkApplication.yaml
@@ -1,0 +1,75 @@
+type: object
+required:
+- id
+- displayName
+- accountId
+- organizationId
+- userId
+- clusterId
+- controllerClusterId
+- appState
+- submissionSource
+- createdAt
+- updatedAt
+allOf:
+- $ref: "../../../../commons/schemas/createdAtUpdatedAt.yaml"
+- type: object
+  description: >
+    The description of a Spark application
+  properties:
+    id:
+      $ref: "oceanSparkApplicationId.yaml"
+    displayName:
+      $ref: "oceanSparkApplicationDisplayName.yaml"
+    userId:
+      $ref: "userId.yaml"
+    clusterId:
+      $ref: "oceanSparkClusterId.yaml"
+    controllerClusterId:
+      $ref: "controllerClusterId.yaml"
+    appState:
+      $ref: "oceanSparkApplicationState.yaml"
+    submissionSource:
+      $ref: "oceanSparkApplicationSubmissionSource.yaml"
+    job:
+      type: object
+      description: >
+        The job to which the application belongs.
+        A job is collection of Spark applications, typically a workload run on a schedule.
+      required:
+        - id
+        - displayName
+      properties:
+        id:
+          $ref: oceanSparkJobId.yaml
+        displayName:
+          $ref: oceanSparkJobDisplayName.yaml
+    config:
+      $ref: "oceanSparkApplicationSpec.yaml"
+    startedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application started running (the app state becomes RUNNING).
+        This is not the time when the application launch was requested (this is `createdAt`).
+      example: "2021-11-18T17:09:37+00:00"
+    endedAt:
+      type: string
+      format: date-time
+      description: >
+        The time when the Spark application terminated.
+      example: "2021-11-18T17:09:37+00:00"
+    liveLog:
+      type: object
+      description: API pointers to endpoints serving logs and events related to the Spark application
+      properties:
+        logsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving the live driver logs
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/logs/live
+        kubeEventsStreamUrl:
+          type: string
+          format: uri
+          description: URL of the endpoint serving a stream of Kubernetes events
+          example: /ocean/spark/cluster/osc-20fac3f1/app/daily-reporting-2021-08-18/kubeEvents/live


### PR DESCRIPTION
# Why

We know use different models for each spark app endpoints in Ocean Spark API.

# What

- Added dedicated models for spark app to reflect differences between api responses

I didn't remove the default spark app model as it is still referenced by jobs endpoints. It should be replaced when these endpoints get updated with new api models