### PR TITLE
[ocean spark] fix oceanSparkApplicationSparkMetrics

### DIFF
--- a/api/services/ocean/spark/schemas/oceanSparkApplicationSparkMetrics.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkApplicationSparkMetrics.yaml
@@ -29,11 +29,6 @@ properties:
     type: integer
     description: >
       The number of bytes written by Spark, typically to an object store.
-  durationSeconds:
-    description: >
-      The duration of the Spark application
-    format: time-delta
-    type: number
   efficiencyPercent:
     type: number
     description: >


### PR DESCRIPTION
The `durationSeconds` field should not be here, it does not exist in the actual responses.

