### PR TITLE
Ocean Spark app namespaces config

### DIFF
--- a/api/services/ocean/spark/schemas/oceanSparkClusterConfig.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkClusterConfig.yaml
@@ -10,3 +10,5 @@ properties:
     $ref: "oceanSparkClusterConfigCompute.yaml"
   logCollection:
     $ref: "oceanSparkClusterConfigLogCollection.yaml"
+  spark:
+    $ref: "oceanSparkClusterConfigSpark.yaml"

--- a/api/services/ocean/spark/schemas/oceanSparkClusterConfigSpark.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkClusterConfigSpark.yaml
@@ -8,4 +8,4 @@ properties:
       type: string
       example: [ "spark-apps", "spark-apps-extra-ns-1", "spark-apps-extra-ns-2" ]
     description: |
-      List of Kubernetes namespaces that Spark applications can run in. The default namespace **spark-apps** is always included in the list.
+      List of Kubernetes namespaces that Spark applications can run in. The default namespace `spark-apps` is always included in the list.

--- a/api/services/ocean/spark/schemas/oceanSparkClusterConfigSpark.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkClusterConfigSpark.yaml
@@ -8,4 +8,4 @@ properties:
       type: string
       example: [ "spark-apps", "spark-apps-extra-ns-1", "spark-apps-extra-ns-2" ]
     description: |
-      List of kubernetes namespaces that Spark applications can be run in. The default namespace **spark-apps** is always included in the list.
+      List of Kubernetes namespaces that Spark applications can run in. The default namespace **spark-apps** is always included in the list.

--- a/api/services/ocean/spark/schemas/oceanSparkClusterConfigSpark.yaml
+++ b/api/services/ocean/spark/schemas/oceanSparkClusterConfigSpark.yaml
@@ -1,0 +1,11 @@
+type: object
+description: >
+  The object specifying the Ocean Spark Spark configuration.
+properties:
+  appNamespaces:
+    type: array
+    items:
+      type: string
+      example: [ "spark-apps", "spark-apps-extra-ns-1", "spark-apps-extra-ns-2" ]
+    description: |
+      List of kubernetes namespaces that Spark applications can be run in. The default namespace **spark-apps** is always included in the list.


### PR DESCRIPTION
- Add Ocean Spark `spark.appNamespaces` cluster config