### PR TITLE
Fixing bug

### DIFF
--- a/api/services/elastigroup/aws/schemas/elastigroupCreate.yaml
+++ b/api/services/elastigroup/aws/schemas/elastigroupCreate.yaml
@@ -776,7 +776,7 @@ properties:
                 taskType:
                   type: string
                   description: | 
-                    The task type to run. For stateful groups, use only those who has a `stateful` prefix. For non-stateful group, use the rest.
+                    The task type to run. For stateful groups, use only those who has a `stateful` prefix, or `backup_ami`. For non-stateful group, use the rest.
                   enum: [backup_ami, scale, scaleUp, percentageScaleUp, scaleDown, percentageScaleDown, roll, clusterRoll (For ECS Integration), statefulUpdateCapacity, statefulRecycle]
                   example: scale
                 scaleTargetCapacity:


### PR DESCRIPTION
                    The task type to run. For stateful groups, use only those who has a `stateful` prefix, or `backup_ami`. For non-stateful group, use the rest.
