### PR TITLE
AWSEG-20111 Volume Attachments

### DIFF
--- a/api/services/elastigroup/aws/schemas/elastigroup-compute.yaml
+++ b/api/services/elastigroup/aws/schemas/elastigroup-compute.yaml
@@ -107,6 +107,8 @@ properties:
     items:
       type: string
       example: ["us-east-1a","us-east-1b"]
+  volumeAttachments:
+    $ref: "./volumeAttachments.yaml"
   launchSpecification:
     type: object
     properties:

--- a/api/services/elastigroup/aws/schemas/elastigroupCreate.yaml
+++ b/api/services/elastigroup/aws/schemas/elastigroupCreate.yaml
@@ -716,6 +716,9 @@ properties:
                 default: true
                 example: true
 
+          volumeAttachments:
+            $ref: "./volumeAttachments.yaml"
+
       scaling:
         type: object
         title: Elastigroup Scaling

--- a/api/services/elastigroup/aws/schemas/import-asg-example2.yaml
+++ b/api/services/elastigroup/aws/schemas/import-asg-example2.yaml
@@ -122,7 +122,7 @@ properties:
                   type: object
                   properties:
                     deleteOnTermination:
-                      type: booleang
+                      type: boolean
                       title: Delete On Termination
                       example: true
                     volumeSize:

--- a/api/services/elastigroup/aws/schemas/volumeAttachments.yaml
+++ b/api/services/elastigroup/aws/schemas/volumeAttachments.yaml
@@ -1,0 +1,31 @@
+type: object
+title: AWS Volume Attachments
+description: |
+  Any volumes specified in this field will be automatically attached to every instance launched in the group.
+  If your group has more than one instance or you want to share the same volume between several instances,
+  it's important to use [Amazon EBS Multi-Attach supported volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html).
+  to enable concurrent attachment of the volumes to multiple instances. This ensures that your volumes can be effectively
+  shared among instances in your group.
+required:
+  - volumes
+properties:
+  volumes:
+    type: array
+    items:
+      type: object
+      required:
+        - volumeId
+        - deviceName
+      properties:
+        volumeId:
+          type: string
+          description: |
+            The volume id to attach
+          example: "vol-1234567"
+        deviceName:
+          type: string
+          description: |
+            The data device name to attach. When you attach a volume to your instance, you include a device name for the volume.
+            Do not use a device name that reserved for the root volume (For example - `/dev/sda1` or `/dev/xvda`).
+          example: "/dev/sdb"
+

--- a/api/services/elastigroup/aws/schemas/volumeAttachments.yaml
+++ b/api/services/elastigroup/aws/schemas/volumeAttachments.yaml
@@ -3,7 +3,7 @@ title: AWS Volume Attachments
 description: |
   Any volumes specified in this field will be automatically attached to every instance launched in the group.
   If your group has more than one instance or you want to share the same volume between several instances,
-  it's important to use [Amazon EBS Multi-Attach supported volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html).
+  it's important to use [Amazon EBS Multi-Attach supported volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html)
   to enable concurrent attachment of the volumes to multiple instances. This ensures that your volumes can be effectively
   shared among instances in your group.
 required:
@@ -25,7 +25,7 @@ properties:
         deviceName:
           type: string
           description: |
-            The data device name to attach. When you attach a volume to your instance, you include a device name for the volume.
-            Do not use a device name that reserved for the root volume (For example - `/dev/sda1` or `/dev/xvda`).
+            The device name to attach. When you attach a volume to your instance, you include a device name for the volume.
+            Do not use a device name that is reserved for the root volume (for example - `/dev/sda1` or `/dev/xvda`).
           example: "/dev/sdb"
 

--- a/api/services/managedInstance/aws/schemas/mi-compute.yaml
+++ b/api/services/managedInstance/aws/schemas/mi-compute.yaml
@@ -33,6 +33,8 @@ properties:
     description: >
       Operation system type. Possible values: Linux/UNIX, SUSE Linux, Windows, Red Hat Enterprise Linux
       In case of EC2 classic: Linux/UNIX (Amazon VPC), SUSE Linux (Amazon VPC), Windows (Amazon VPC), Red Hat Enterprise Linux (Amazon VPC)
+  volumeAttachments:
+    $ref: "../../../elastigroup/aws/schemas/volumeAttachments.yaml"
   launchSpecification:
     type: object
     properties:


### PR DESCRIPTION
- Supporting new field names `VolumeAttachments` for both Elastigroup / Stateful Node objects.
- Any volumes specified in this field will be automatically attached to every instance launched in the group.

# Jira Ticket
[AWSEG-20111](https://spotinst.atlassian.net/browse/AWSEG-20111)

# Checklist:

# Screenshots:
![image](https://user-images.githubusercontent.com/93710668/233992989-6aacac4a-2ba9-4eb8-9767-097a1c252538.png)
![image](https://user-images.githubusercontent.com/93710668/233993194-0ad90b71-3908-429b-8cba-08795f2954e4.png)
Added to create/update EG/Stateful node schemas and equivalent request and response examples


[AWSEG-20111]: https://spotinst.atlassian.net/browse/AWSEG-20111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ