### PR TITLE
feature/AZUEG-12754-EG-|-Azure-|-Stateful-Node-|-Feature-to-removing-VM-from-Spot-without-deregistering-from-LB

### DIFF
--- a/api/services/elastigroup/azure/stateful/node/schemas/deleteStatefulNode.yaml
+++ b/api/services/elastigroup/azure/stateful/node/schemas/deleteStatefulNode.yaml
@@ -12,6 +12,12 @@ properties:
         description: |
           Indicates whether to delete the stateful node's VM.
         example: true
+      shouldDeregisterFromLb:
+        type: boolean
+        default: true
+        description: |
+          Indicates whether to deregister the stateful node's VM from any type of load balancer.
+        example: true
       networkDeallocationConfig:
         type: object
         title: Network Deallocation Config


### PR DESCRIPTION
AZUEG-12754-EG-|-Azure-|-Stateful-Node-|-Feature-to-removing-VM-from-Spot-without-deregistering-from-LB
# Jira Ticket
https://spotinst.atlassian.net/browse/AZUEG-12754