### PR TITLE
AZUEG-12763 FR | EG | Azure | Stateless | Feature to remove VM from Spot without deregistering from LB

### DIFF
--- a/api/services/elastigroup/azure/spotVms/paths/groupVmDetach.yaml
+++ b/api/services/elastigroup/azure/spotVms/paths/groupVmDetach.yaml
@@ -36,6 +36,12 @@ put:
               example: true
               description: |
                 Prevent Elastigroup from scaling back to target capacity when virtual machines are detached.
+            shouldDeregisterVmFromLb:
+              type: boolean
+              default: true
+              example: true
+              description: |
+                Indicates whether to deregister the stateful node's VM from any type of load balancer. Will only be applied if the shouldTerminateVms is 'false'
             drainingTimeout:
               type: string
               example: 300


### PR DESCRIPTION
AZUEG-12763
FR | EG | Azure | Stateless | Feature to remove VM from Spot without deregistering from LB

# Jira Ticket

https://spotinst.atlassian.net/browse/AZUEG-12763