### PR TITLE
CON-34744 - get rid of unused `labelValuesByLabelKeyByNamespace` property

### DIFF
--- a/api/services/ocean/rightsizing/schemas/oceanRightsizingRuleAutoApplyDefinition.yaml
+++ b/api/services/ocean/rightsizing/schemas/oceanRightsizingRuleAutoApplyDefinition.yaml
@@ -6,15 +6,17 @@ properties:
     type: boolean
     description: Determines if auto apply is enabled.
     example: true
-  labelValuesByLabelKeyByNamespace:
+  namespaces:
+    type: array
+    description: A list of namespaces to which the auto apply rule applies.
+    items:
+      type: string
+    example: ["namespace1", "namespace2", "namespace3"]
+  labels:
     type: object
-    description: A mapping of a namespace to different keys and their different values existing in the namespace.
-    example:  {
-      namespaceName1: {
-        key1: ["value1", "value2"],
-        key2: ["value3"]
-      },
-      namespaceName2: {
-        key1: ["value1", "value2"]
-      }
+    description: |
+      A set of key-value label pairs used to automatically apply this rule to all workloads in the cluster that match these labels.
+    example: {
+      "app": "my-app",
+      "environment": "production"
     }


### PR DESCRIPTION
https://spotinst.atlassian.net/browse/CON-34744

## Why
The current [Right Sizing](https://docs.spot.io/api/#tag/Ocean-Automatic-Rightsizing/operation/oceanRightsizingRuleCreate) payload is not correct

## What
 - remove unused `labelValuesByLabelKeyByNamespace` property
 - add and document missing properties:
   - namespaces
   - labels

# Demo

<img width="818" alt="image" src="https://github.com/user-attachments/assets/252980ae-0283-4de1-b959-7f0dd5d182af" />

<img width="344" alt="image" src="https://github.com/user-attachments/assets/bc95e4d1-35aa-4892-aeca-037a44015b5c" />

