### PR TITLE
DOC-2840 - [src] added primaryIpv6 to ocean cluster compute object 

### DIFF
--- a/api/services/ocean/aws/schemas/ocean-compute.yaml
+++ b/api/services/ocean/aws/schemas/ocean-compute.yaml
@@ -127,6 +127,13 @@ properties:
           Not required if the subnet is configured to “auto assign ipv6 addresses”.
         default: false
         example: false
+      primaryIpv6:
+        type: boolean
+        example: false
+        description: >
+          Enables assignment of a primary IPv6 address to the cluster.
+          This feature is only available when `associateIpv6Addresses` is explicitly set to `true`.
+          Additionally, the cluster must have been initially created as an EKS cluster in IPv6 mode.
       monitoring:
         type: boolean
         description: >


### PR DESCRIPTION
https://spotinst.atlassian.net/browse/DOC-2840

# Demo


https://spotinst.atlassian.net/browse/DOC-2840


<details open>
  <summary><a href="https://spotinst.atlassian.net/browse/DOC-2840" title="DOC-2840" target="_blank">DOC-2840</a></summary>
https://spotinst.atlassian.net/browse/DOC-2840
 
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

