### PR TITLE
SPOTCON-36834: Support API parameter for dynamic replacement limit in OpenAPI documentation

### DIFF
--- a/api/services/ocean/aws/schemas/ocean-strategy.yaml
+++ b/api/services/ocean/aws/schemas/ocean-strategy.yaml
@@ -24,6 +24,14 @@ properties:
       The desired percentage of Spot instances out of all running instances.\
       Only available when the field is **not** set in any VNG directly (launchSpec.strategy.spotPercentage).
     example: 100
+  maxReplacementLimitPercentage:
+    type: integer
+    default: 10
+    minimum: 1
+    maximum: 100
+    description: |
+      Limits the percentage of instances that can be replaced at once during a run cycle.
+    example: 25
   gracePeriod:
     type: integer
     default: 300


### PR DESCRIPTION
# Jira ticket
https://flexera.atlassian.net/browse/SPOTCON-36834

# Summary
The Ocean API is introducing support for a dynamic replacement‑limit parameter, and the OpenAPI documentation needs to be updated to reflect this new capability. Ensuring the OpenAPI spec includes this parameter keeps the documentation aligned with the latest supported features of the Ocean API and provides accurate guidance for customers and integrators.

# Demo

## HTML - Create Cluster
<img width="1261" height="705" alt="html_create_cluster" src="https://github.com/user-attachments/assets/514bae44-9e54-4bf4-af6c-dae32278687a" />

## HTML - Update Cluster
<img width="1265" height="886" alt="html_update_cluster" src="https://github.com/user-attachments/assets/91c9ac85-6aca-4e54-af2a-b5fd26d1c71b" />

## Redoc Serve - Create Cluster
<img width="1332" height="714" alt="redoc_serve_create_cluster" src="https://github.com/user-attachments/assets/b2418bda-fe22-4cc9-9921-5f4c4747d099" />

## Redoc Serve - Update Cluster
<img width="1266" height="860" alt="redoc_serve_update_cluster" src="https://github.com/user-attachments/assets/95238c39-05fb-468a-8925-3bc9d1b4c8fd" />

## Swagger JSON
<img width="675" height="1077" alt="swagger json bundle" src="https://github.com/user-attachments/assets/b2c995d0-0a40-450a-834c-96261cd71fc9" />

## OpenAPI Schema Validation
<img width="1423" height="121" alt="Valid against OpenAPI shema" src="https://github.com/user-attachments/assets/d8e544ce-3d03-4a5c-a5a0-f8b10c3732ee" />
