### PR TITLE
SOD-7837 Updated the Ocean Right-Sizing Savings OpenAPI documentation.

### DIFF
--- a/api/services/ocean/rightsizing/responses/oceanRightsizingSavingsResponse.yaml
+++ b/api/services/ocean/rightsizing/responses/oceanRightsizingSavingsResponse.yaml
@@ -32,7 +32,7 @@ content:
                       - namespace: "default"
                         savings: 500
                       workloadSavings:
-                      - workloadName: "coredns"
+                      - name: "coredns"
                         workloadType: "Deployment"
                         namespace: "kube-system"
                         cpuWithOcean: 25
@@ -40,8 +40,8 @@ content:
                         memoryWithOcean: 32
                         memoryWithoutOcean: 64
                         savings: 250
-                        isDeleted: True
-                      - workloadName: "aws-node"
+                        workloadDeleted: true
+                      - name: "aws-node"
                         workloadType: "DaemonSet"
                         namespace: "kube-system"
                         cpuWithOcean: 25
@@ -49,7 +49,7 @@ content:
                         memoryWithOcean: 32
                         memoryWithoutOcean: 64
                         savings: 250
-                        isDeleted": False
+                        workloadDeleted: false
                 count:
                   example: 1
                 kind:

--- a/api/services/ocean/rightsizing/schemas/oceanRightsizingSavings.yaml
+++ b/api/services/ocean/rightsizing/schemas/oceanRightsizingSavings.yaml
@@ -31,7 +31,7 @@ properties:
     items:
       type: object
       properties:
-        workloadName:
+        name:
           type: string
         workloadType:
           type: string
@@ -47,7 +47,7 @@ properties:
           type: number
         savings:
           type: number
-        isDeleted:
+        workloadDeleted:
           type: boolean
 
 

--- a/api/services/ocean/rightsizing/schemas/oceanRightsizingSavingsRequest.yaml
+++ b/api/services/ocean/rightsizing/schemas/oceanRightsizingSavingsRequest.yaml
@@ -3,10 +3,16 @@ title: Ocean Right-Sizing Savings
 description: >
   Determines the Ocean right-sizing savings
 required:
+  - clusterIdentifier
   - endTime
   - startTime
   - workloads
 properties:
+  clusterIdentifier:
+    type: string
+    example: "my-cluster"
+    description: >
+      Identifier of the Ocean cluster.
   startTime:
     type: string
     example: 2025-01-20T11:35:02.745Z

--- a/api/services/ocean/rightsizing/schemas/oceanRightsizingSavingsWorkloadsRequest.yaml
+++ b/api/services/ocean/rightsizing/schemas/oceanRightsizingSavingsWorkloadsRequest.yaml
@@ -10,7 +10,7 @@ properties:
       items:
         type: object
         properties:
-          workloadName:
+          name:
             type: string
             description: The name of the workload
           workloadType:
@@ -19,12 +19,12 @@ properties:
 
 example:
   namespaceName1:
-  - workloadName: workloadName1
+  - name: workloadName1
     workloadType: Deployment
-  - workloadName: workloadName2
+  - name: workloadName2
     workloadType: DaemonSet
   namespaceName2:
-  - workloadName: workloadName3
+  - name: workloadName3
     workloadType: StatefulSet
-  - workloadName: workloadName4
+  - name: workloadName4
     workloadType: Deployment


### PR DESCRIPTION
## Jira

https://flexera.atlassian.net/browse/SOD-7837

## Summary

This PR updates the OpenAPI documentation for the **Get Ocean Right-Sizing Savings** endpoint to match the current API implementation.

## Changes

- Added the required `clusterIdentifier` field to the request schema.
- Renamed the workload attribute from `workloadName` to `name` in the request and response schemas.
- Renamed the response field from `isDeleted` to `workloadDeleted`.
- Updated request and response examples to reflect the latest schema.
- Fixed the response example to use valid boolean values.

## Validation

- Verified the OpenAPI specification is valid.
- Confirmed the generated documentation reflects the updated request and response structures.

# Demo

before updating-
<img width="265" height="450" alt="Screenshot 2026-07-14 at 8 31 01 AM" src="https://github.com/user-attachments/assets/a6a5f57b-d444-4a41-a4a3-52a8488be3a3" />
<img width="710" height="430" alt="Screenshot 2026-07-14 at 8 30 40 AM" src="https://github.com/user-attachments/assets/ea255a7a-cf14-4bd9-84a9-88ba4cf60c61" />



after updating-
<img width="265" height="450" alt="Screenshot 2026-07-14 at 8 30 09 AM" src="https://github.com/user-attachments/assets/d00775d7-937e-404e-9ded-e4f2b36e9c3c" />
<img width="710" height="430" alt="Screenshot 2026-07-14 at 8 29 23 AM" src="https://github.com/user-attachments/assets/74e694c7-c1e7-47c9-b669-2ef16ccc0ca6" />
