### PR TITLE
feat: SOD-7881 Update openApi spec to set, get and update recommendation baseline percentile in OceanRightSizingRule

### DIFF
--- a/api/services/ocean/rightsizing/responses/oceanRightsizingRule.yaml
+++ b/api/services/ocean/rightsizing/responses/oceanRightsizingRule.yaml
@@ -37,6 +37,14 @@ properties:
     $ref: "../schemas/oceanRightsizingRuleRecommendationApplicationHPA.yaml"
   autoApplyDefinition:
     $ref: "../schemas/oceanRightsizingRuleAutoApplyDefinition.yaml"
+  cpuPercentile:
+    type: integer
+    description: vCPU percentile for calculating recommendations.
+    example: 95
+  memoryPercentile:
+    type: integer
+    description: Memory percentile for calculating recommendations.
+    example: 90
   downsideOnly:
     type: boolean
     description: When set to 'true', only downscale recommendations will be applied.

--- a/api/services/ocean/rightsizing/schemas/oceanRightsizingRuleRequest.yaml
+++ b/api/services/ocean/rightsizing/schemas/oceanRightsizingRuleRequest.yaml
@@ -37,6 +37,14 @@ properties:
     $ref: "../schemas/oceanRightsizingRuleRecommendationApplicationHPA.yaml"
   autoApplyDefinition:
     $ref: "../schemas/oceanRightsizingRuleAutoApplyDefinition.yaml"
+  cpuPercentile:
+    type: integer
+    description: vCPU percentile for calculating recommendations.
+    example: 95
+  memoryPercentile:
+    type: integer
+    description: Memory percentile for calculating recommendations.
+    example: 90
   downsideOnly:
     type: boolean
     description: When set to 'true', only downscale recommendations will be applied.

--- a/api/services/ocean/rightsizing/schemas/oceanRightsizingUpdateRuleRequest.yaml
+++ b/api/services/ocean/rightsizing/schemas/oceanRightsizingUpdateRuleRequest.yaml
@@ -33,6 +33,14 @@ properties:
     $ref: "../schemas/oceanRightsizingRuleRecommendationApplicationHPA.yaml"
   autoApplyDefinition:
     $ref: "../schemas/oceanRightsizingRuleAutoApplyDefinition.yaml"
+  cpuPercentile:
+    type: integer
+    description: vCPU percentile for calculating recommendations.
+    example: 95
+  memoryPercentile:
+    type: integer
+    description: Memory percentile for calculating recommendations.
+    example: 90
   downsideOnly:
     type: boolean
     description: When set to 'true', only downscale recommendations will be applied.


### PR DESCRIPTION
# Demo

<img width="1698" height="994" alt="image" src="https://github.com/user-attachments/assets/9115eede-d434-4923-aea0-489dff214361" />

<img width="1722" height="1001" alt="image" src="https://github.com/user-attachments/assets/81e1fcc9-8652-4958-9984-4704a1cf21ee" />

