### PR TITLE
SOD-782: Add 'reportPartialCompletion' field to cluster roll initiation.

### DIFF
--- a/api/services/ocean/aws/paths/clusters-roll.yaml
+++ b/api/services/ocean/aws/paths/clusters-roll.yaml
@@ -26,6 +26,7 @@ post:
                   - $ref: "../schemas/roll/roll-comment.yaml"
                   - $ref: "../schemas/roll/roll-respectPdb.yaml"
                   - $ref: "../schemas/roll/roll-batchMinHealthyPercentage.yaml"
+                  - $ref: "../schemas/roll/roll-reportPartialCompletion.yaml"
             - type: object
               title: 'Roll with instance ids'
               properties:
@@ -36,6 +37,7 @@ post:
                     - $ref: "../schemas/roll/roll-respectPdb.yaml"
                     - $ref: "../schemas/roll/roll-batchMinHealthyPercentage.yaml"
                     - $ref: "../schemas/roll/roll-instanceIds.yaml"
+                    - $ref: "../schemas/roll/roll-reportPartialCompletion.yaml"
             - type: object
               title: 'Roll with Virtual Node Group ids'
               properties:
@@ -47,6 +49,7 @@ post:
                     - $ref: "../schemas/roll/roll-batchMinHealthyPercentage.yaml"
                     - $ref: "../schemas/roll/roll-launchSpecIds.yaml"
                     - $ref: "../schemas/roll/roll-disableLaunchSpecAutoScaling.yaml"
+                    - $ref: "../schemas/roll/roll-reportPartialCompletion.yaml"
   responses:
     200:
       $ref: "../responses/initiate-clusterRoll.yaml"

--- a/api/services/ocean/aws/responses/clusterRollGetAllResponse.yaml
+++ b/api/services/ocean/aws/responses/clusterRollGetAllResponse.yaml
@@ -30,7 +30,7 @@ content:
                 example: Cluster
               status:
                 type: string
-                enum: [IN_PROGRESS, COMPLETED, FAILED, STOPPED]
+                enum: [IN_PROGRESS, COMPLETED, PARTIALLY_COMPLETED, FAILED, STOPPED]
                 example: IN_PROGRESS
               currentBatch:
                 type: integer
@@ -94,6 +94,9 @@ content:
               batchMinHealthyPercentage:
                 type: integer
                 example: 100
+              reportPartialCompletion:
+                type: boolean
+                example: true
               createdAt:
                 type: string
                 example: 2019-03-24T15:46:09.000Z

--- a/api/services/ocean/aws/responses/initiate-clusterRoll.yaml
+++ b/api/services/ocean/aws/responses/initiate-clusterRoll.yaml
@@ -13,7 +13,7 @@ content:
           example: Cluster
         status:
           type: string
-          enum: [IN_PROGRESS, COMPLETED, FAILED, STOPPED]
+          enum: [IN_PROGRESS, COMPLETED, PARTIALLY_COMPLETED, FAILED, STOPPED]
           example: IN_PROGRESS
         currentBatch:
           type: integer
@@ -77,6 +77,9 @@ content:
         batchMinHealthyPercentage:
           type: integer
           example: 100
+        reportPartialCompletion:
+          type: boolean
+          example: true
         createdAt:
           type: string
           example: 2019-03-24T15:46:09.000Z

--- a/api/services/ocean/aws/schemas/roll/roll-reportPartialCompletion.yaml
+++ b/api/services/ocean/aws/schemas/roll/roll-reportPartialCompletion.yaml
@@ -3,6 +3,6 @@ properties:
   reportPartialCompletion:
     type: boolean
     description: >
-      When true, a roll that ends with a mix of successfully and unsuccessfully replaced instances is reported as PARTIALLY_COMPLETED instead of FAILED. Defaults to false, preserving the legacy behavior of reporting FAILED for any mixed result.
+      When set to true, a roll that ends with a mixed result of successfully and unsuccessfully replaced instances is reported as PARTIALLY_COMPLETED. When set to false, a mixed result is reported as FAILED.
     example: true
     default: false

--- a/api/services/ocean/aws/schemas/roll/roll-reportPartialCompletion.yaml
+++ b/api/services/ocean/aws/schemas/roll/roll-reportPartialCompletion.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  reportPartialCompletion:
+    type: boolean
+    description: >
+      When true, a roll that ends with a mix of successfully and unsuccessfully replaced instances is reported as PARTIALLY_COMPLETED instead of FAILED. Defaults to false, preserving the legacy behavior of reporting FAILED for any mixed result.
+    example: true
+    default: false


### PR DESCRIPTION
# What
- Added documentation for the new roll request flag 'reportPartialCompletion' in Ocean AWS Kubernetes roll initiation.

Documented behavior of the flag:
 - When true, mixed roll outcomes are reported as PARTIALLY_COMPLETED.
 - When omitted or false, legacy behavior is preserved and mixed outcomes are reported as FAILED.

# Demo

## Redoc - Initiate Roll
<img width="1842" height="993" alt="initiate-roll" src="https://github.com/user-attachments/assets/765c1d76-4e0b-406a-973e-ef10348565b6" />

## Redoc - Get Roll
<img width="1759" height="1133" alt="get roll" src="https://github.com/user-attachments/assets/f1f78573-9570-4a90-8c3c-ce29a74258bd" />

## Html - Initiate Roll
<img width="1883" height="922" alt="html_initiate_roll" src="https://github.com/user-attachments/assets/4db8cb31-c35d-479d-907f-4de3507a1861" />


## Html - Get Roll
<img width="1818" height="1027" alt="html_get_roll" src="https://github.com/user-attachments/assets/39144fe3-5ab3-45fb-98d1-9e988fe4dde7" />

## Swagger Json
<img width="946" height="871" alt="swagger-json" src="https://github.com/user-attachments/assets/384ecbab-a36f-4229-94ce-aea799493da0" />

## Schema Validation
<img width="2289" height="193" alt="valid_schema" src="https://github.com/user-attachments/assets/3dfe9c51-bfff-4833-a594-65c59e406b8b" />
