### PR TITLE
feat(SOD-7924): Azure Ocean AKS LocalDNS Profile Support — openapi

### DIFF
--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -1,0 +1,29 @@
+type: object
+title: Ocean AKS LocalDNS Profile
+description: |
+  AKS LocalDNS profile configuration for the VNG.
+  Requires VM sizes with at least 4 vCPUs and Linux (Ubuntu 22.04+ or Azure Linux) OS.
+  See: https://learn.microsoft.com/en-us/azure/aks/localdns-custom
+properties:
+  mode:
+    type: string
+    description: |
+      The LocalDNS mode. Required when localDnsProfile is configured.
+    enum: [ Required, Preferred, Disabled ]
+    example: Required
+  vnetDNSOverrides:
+    type: object
+    description: |
+      Per-zone DNS override configuration for VNet DNS resolution.
+      Keys are DNS zone names (e.g. "." or "cluster.local").
+    additionalProperties:
+      type: object
+  kubeDNSOverrides:
+    type: object
+    description: |
+      Per-zone DNS override configuration for kube-dns/CoreDNS resolution.
+      Keys are DNS zone names (e.g. "." or "cluster.local").
+    additionalProperties:
+      type: object
+required:
+  - mode

--- a/api/services/ocean/aks/schemas/ocean-nodePoolProperties.yaml
+++ b/api/services/ocean/aks/schemas/ocean-nodePoolProperties.yaml
@@ -68,3 +68,5 @@ properties:
     example: [ "/subscriptions/123456-1234-1234-1234-123456789/resourceGroups/ExampleResourceGroup/providers/Microsoft.Network/virtualNetworks/ExampleVirtualNetwork/subnets/default" ]
   linuxOSConfig:
     $ref: "ocean-linuxOSConfig.yaml"
+  localDnsProfile:
+    $ref: "ocean-localDnsProfile.yaml"

--- a/api/services/ocean/aks/schemas/update/ocean-nodePoolProperties.yaml
+++ b/api/services/ocean/aks/schemas/update/ocean-nodePoolProperties.yaml
@@ -57,3 +57,5 @@ properties:
     example: [ "/subscriptions/123456-1234-1234-1234-123456789/resourceGroups/ExampleResourceGroup/providers/Microsoft.Network/virtualNetworks/ExampleVirtualNetwork/subnets/default" ]
   linuxOSConfig:
     $ref: "../ocean-linuxOSConfig.yaml"
+  localDnsProfile:
+    $ref: "../ocean-localDnsProfile.yaml"


### PR DESCRIPTION
Adds `localDnsProfile` to VNG nodePoolProperties schema.

Changes:
- New schema: ocean-localDnsProfile.yaml (mode, vnetDNSOverrides, kubeDNSOverrides)
- ocean-nodePoolProperties.yaml: adds localDnsProfile ref (create/import)
- update/ocean-nodePoolProperties.yaml: adds localDnsProfile ref (update)

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
