### PR TITLE
feat(SOD-7924): Azure Ocean AKS LocalDNS Profile Support — openapi

### DIFF
--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -1,0 +1,29 @@
+type: object
+title: Ocean AKS LocalDNS Profile
+description: |
+  AKS LocalDNS profile configuration for the VNG.
+  Requires VM sizes with at least 4 vCPUs and Linux (Ubuntu 22.04+ or Azure Linux) OS.
+  See: https://learn.microsoft.com/en-us/azure/aks/localdns-custom
+properties:
+  mode:
+    type: string
+    description: |
+      The LocalDNS mode. Required when localDnsProfile is configured.
+    enum: [ Required, Preferred, Disabled ]
+    example: Required
+  vnetDNSOverrides:
+    type: object
+    description: |
+      Per-zone DNS override configuration for VNet DNS resolution.
+      Keys are DNS zone names (e.g. "." or "cluster.local").
+    additionalProperties:
+      type: object
+  kubeDNSOverrides:
+    type: object
+    description: |
+      Per-zone DNS override configuration for kube-dns/CoreDNS resolution.
+      Keys are DNS zone names (e.g. "." or "cluster.local").
+    additionalProperties:
+      type: object
+required:
+  - mode

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -58,8 +58,29 @@ properties:
       Keys are DNS zone names (e.g. "." or "cluster.local").
 
       Example:
-      "." : { queryLogging: Error, protocol: PreferUDP, forwardDestination: VnetDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
-      "cluster.local" : { queryLogging: Error, protocol: ForceTCP, forwardDestination: ClusterCoreDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
+
+      {
+        ".": {
+          "queryLogging": "Error",
+          "protocol": "PreferUDP",
+          "forwardDestination": "VnetDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        },
+        "cluster.local": {
+          "queryLogging": "Error",
+          "protocol": "ForceTCP",
+          "forwardDestination": "ClusterCoreDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        }
+      }
     example:
       ".":
         queryLogging: Error
@@ -86,8 +107,29 @@ properties:
       Keys are DNS zone names (e.g. "." or "cluster.local").
 
       Example:
-      "." : { queryLogging: Error, protocol: PreferUDP, forwardDestination: ClusterCoreDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
-      "cluster.local" : { queryLogging: Error, protocol: ForceTCP, forwardDestination: ClusterCoreDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
+
+      {
+        ".": {
+          "queryLogging": "Error",
+          "protocol": "PreferUDP",
+          "forwardDestination": "ClusterCoreDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        },
+        "cluster.local": {
+          "queryLogging": "Error",
+          "protocol": "ForceTCP",
+          "forwardDestination": "ClusterCoreDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        }
+      }
     example:
       ".":
         queryLogging: Error

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -47,9 +47,8 @@ example:
 properties:
   mode:
     type: string
-    description: |
-      The LocalDNS mode. Required when localDnsProfile is configured.
     enum: [ Required, Preferred, Disabled ]
+    description: The LocalDNS mode. Required when localDnsProfile is configured.
     example: Required
   vnetDNSOverrides:
     type: object
@@ -83,25 +82,6 @@ properties:
         }
       }
       ```
-    example:
-      ".":
-        queryLogging: Error
-        protocol: PreferUDP
-        forwardDestination: VnetDNS
-        forwardPolicy: Sequential
-        maxConcurrent: 1000
-        cacheDurationInSeconds: 3600
-        serveStaleDurationInSeconds: 3600
-        serveStale: Immediate
-      "cluster.local":
-        queryLogging: Error
-        protocol: ForceTCP
-        forwardDestination: ClusterCoreDNS
-        forwardPolicy: Sequential
-        maxConcurrent: 1000
-        cacheDurationInSeconds: 3600
-        serveStaleDurationInSeconds: 3600
-        serveStale: Immediate
   kubeDNSOverrides:
     type: object
     description: |
@@ -134,24 +114,5 @@ properties:
         }
       }
       ```
-    example:
-      ".":
-        queryLogging: Error
-        protocol: PreferUDP
-        forwardDestination: ClusterCoreDNS
-        forwardPolicy: Sequential
-        maxConcurrent: 1000
-        cacheDurationInSeconds: 3600
-        serveStaleDurationInSeconds: 3600
-        serveStale: Immediate
-      "cluster.local":
-        queryLogging: Error
-        protocol: ForceTCP
-        forwardDestination: ClusterCoreDNS
-        forwardPolicy: Sequential
-        maxConcurrent: 1000
-        cacheDurationInSeconds: 3600
-        serveStaleDurationInSeconds: 3600
-        serveStale: Immediate
 required:
   - mode

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -16,10 +16,48 @@ properties:
     description: |
       Per-zone DNS override configuration for VNet DNS resolution.
       Keys are DNS zone names (e.g. "." or "cluster.local").
+    example:
+      ".":
+        queryLogging: Error
+        protocol: PreferUDP
+        forwardDestination: VnetDNS
+        forwardPolicy: Sequential
+        maxConcurrent: 1000
+        cacheDurationInSeconds: 3600
+        serveStaleDurationInSeconds: 3600
+        serveStale: Immediate
+      "cluster.local":
+        queryLogging: Error
+        protocol: ForceTCP
+        forwardDestination: ClusterCoreDNS
+        forwardPolicy: Sequential
+        maxConcurrent: 1000
+        cacheDurationInSeconds: 3600
+        serveStaleDurationInSeconds: 3600
+        serveStale: Immediate
   kubeDNSOverrides:
     type: object
     description: |
       Per-zone DNS override configuration for kube-dns/CoreDNS resolution.
       Keys are DNS zone names (e.g. "." or "cluster.local").
+    example:
+      ".":
+        queryLogging: Error
+        protocol: PreferUDP
+        forwardDestination: ClusterCoreDNS
+        forwardPolicy: Sequential
+        maxConcurrent: 1000
+        cacheDurationInSeconds: 3600
+        serveStaleDurationInSeconds: 3600
+        serveStale: Immediate
+      "cluster.local":
+        queryLogging: Error
+        protocol: ForceTCP
+        forwardDestination: ClusterCoreDNS
+        forwardPolicy: Sequential
+        maxConcurrent: 1000
+        cacheDurationInSeconds: 3600
+        serveStaleDurationInSeconds: 3600
+        serveStale: Immediate
 required:
   - mode

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -58,30 +58,8 @@ properties:
       Keys are DNS zone names (e.g. "." or "cluster.local").
 
       Example:
-      ```json
-      {
-        ".": {
-          "queryLogging": "Error",
-          "protocol": "PreferUDP",
-          "forwardDestination": "VnetDNS",
-          "forwardPolicy": "Sequential",
-          "maxConcurrent": 1000,
-          "cacheDurationInSeconds": 3600,
-          "serveStaleDurationInSeconds": 3600,
-          "serveStale": "Immediate"
-        },
-        "cluster.local": {
-          "queryLogging": "Error",
-          "protocol": "ForceTCP",
-          "forwardDestination": "ClusterCoreDNS",
-          "forwardPolicy": "Sequential",
-          "maxConcurrent": 1000,
-          "cacheDurationInSeconds": 3600,
-          "serveStaleDurationInSeconds": 3600,
-          "serveStale": "Immediate"
-        }
-      }
-      ```
+      "." : { queryLogging: Error, protocol: PreferUDP, forwardDestination: VnetDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
+      "cluster.local" : { queryLogging: Error, protocol: ForceTCP, forwardDestination: ClusterCoreDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
     example:
       ".":
         queryLogging: Error
@@ -108,30 +86,8 @@ properties:
       Keys are DNS zone names (e.g. "." or "cluster.local").
 
       Example:
-      ```json
-      {
-        ".": {
-          "queryLogging": "Error",
-          "protocol": "PreferUDP",
-          "forwardDestination": "ClusterCoreDNS",
-          "forwardPolicy": "Sequential",
-          "maxConcurrent": 1000,
-          "cacheDurationInSeconds": 3600,
-          "serveStaleDurationInSeconds": 3600,
-          "serveStale": "Immediate"
-        },
-        "cluster.local": {
-          "queryLogging": "Error",
-          "protocol": "ForceTCP",
-          "forwardDestination": "ClusterCoreDNS",
-          "forwardPolicy": "Sequential",
-          "maxConcurrent": 1000,
-          "cacheDurationInSeconds": 3600,
-          "serveStaleDurationInSeconds": 3600,
-          "serveStale": "Immediate"
-        }
-      }
-      ```
+      "." : { queryLogging: Error, protocol: PreferUDP, forwardDestination: ClusterCoreDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
+      "cluster.local" : { queryLogging: Error, protocol: ForceTCP, forwardDestination: ClusterCoreDNS, forwardPolicy: Sequential, maxConcurrent: 1000, cacheDurationInSeconds: 3600, serveStaleDurationInSeconds: 3600, serveStale: Immediate }
     example:
       ".":
         queryLogging: Error

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -59,6 +59,7 @@ properties:
 
       Example:
 
+      ```json
       {
         ".": {
           "queryLogging": "Error",
@@ -81,6 +82,7 @@ properties:
           "serveStale": "Immediate"
         }
       }
+      ```
     example:
       ".":
         queryLogging: Error
@@ -108,6 +110,7 @@ properties:
 
       Example:
 
+      ```json
       {
         ".": {
           "queryLogging": "Error",
@@ -130,6 +133,7 @@ properties:
           "serveStale": "Immediate"
         }
       }
+      ```
     example:
       ".":
         queryLogging: Error

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -56,6 +56,32 @@ properties:
     description: |
       Per-zone DNS override configuration for VNet DNS resolution.
       Keys are DNS zone names (e.g. "." or "cluster.local").
+
+      Example:
+      ```json
+      {
+        ".": {
+          "queryLogging": "Error",
+          "protocol": "PreferUDP",
+          "forwardDestination": "VnetDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        },
+        "cluster.local": {
+          "queryLogging": "Error",
+          "protocol": "ForceTCP",
+          "forwardDestination": "ClusterCoreDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        }
+      }
+      ```
     example:
       ".":
         queryLogging: Error
@@ -80,6 +106,32 @@ properties:
     description: |
       Per-zone DNS override configuration for kube-dns/CoreDNS resolution.
       Keys are DNS zone names (e.g. "." or "cluster.local").
+
+      Example:
+      ```json
+      {
+        ".": {
+          "queryLogging": "Error",
+          "protocol": "PreferUDP",
+          "forwardDestination": "ClusterCoreDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        },
+        "cluster.local": {
+          "queryLogging": "Error",
+          "protocol": "ForceTCP",
+          "forwardDestination": "ClusterCoreDNS",
+          "forwardPolicy": "Sequential",
+          "maxConcurrent": 1000,
+          "cacheDurationInSeconds": 3600,
+          "serveStaleDurationInSeconds": 3600,
+          "serveStale": "Immediate"
+        }
+      }
+      ```
     example:
       ".":
         queryLogging: Error

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -16,14 +16,10 @@ properties:
     description: |
       Per-zone DNS override configuration for VNet DNS resolution.
       Keys are DNS zone names (e.g. "." or "cluster.local").
-    additionalProperties:
-      type: object
   kubeDNSOverrides:
     type: object
     description: |
       Per-zone DNS override configuration for kube-dns/CoreDNS resolution.
       Keys are DNS zone names (e.g. "." or "cluster.local").
-    additionalProperties:
-      type: object
 required:
   - mode

--- a/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
+++ b/api/services/ocean/aks/schemas/ocean-localDnsProfile.yaml
@@ -4,6 +4,46 @@ description: |
   AKS LocalDNS profile configuration for the VNG.
   Requires VM sizes with at least 4 vCPUs and Linux (Ubuntu 22.04+ or Azure Linux) OS.
   See: https://learn.microsoft.com/en-us/azure/aks/localdns-custom
+example:
+  mode: Required
+  vnetDNSOverrides:
+    ".":
+      queryLogging: Error
+      protocol: PreferUDP
+      forwardDestination: VnetDNS
+      forwardPolicy: Sequential
+      maxConcurrent: 1000
+      cacheDurationInSeconds: 3600
+      serveStaleDurationInSeconds: 3600
+      serveStale: Immediate
+    "cluster.local":
+      queryLogging: Error
+      protocol: ForceTCP
+      forwardDestination: ClusterCoreDNS
+      forwardPolicy: Sequential
+      maxConcurrent: 1000
+      cacheDurationInSeconds: 3600
+      serveStaleDurationInSeconds: 3600
+      serveStale: Immediate
+  kubeDNSOverrides:
+    ".":
+      queryLogging: Error
+      protocol: PreferUDP
+      forwardDestination: ClusterCoreDNS
+      forwardPolicy: Sequential
+      maxConcurrent: 1000
+      cacheDurationInSeconds: 3600
+      serveStaleDurationInSeconds: 3600
+      serveStale: Immediate
+    "cluster.local":
+      queryLogging: Error
+      protocol: ForceTCP
+      forwardDestination: ClusterCoreDNS
+      forwardPolicy: Sequential
+      maxConcurrent: 1000
+      cacheDurationInSeconds: 3600
+      serveStaleDurationInSeconds: 3600
+      serveStale: Immediate
 properties:
   mode:
     type: string

--- a/api/services/ocean/aks/schemas/ocean-nodePoolProperties.yaml
+++ b/api/services/ocean/aks/schemas/ocean-nodePoolProperties.yaml
@@ -68,3 +68,5 @@ properties:
     example: [ "/subscriptions/123456-1234-1234-1234-123456789/resourceGroups/ExampleResourceGroup/providers/Microsoft.Network/virtualNetworks/ExampleVirtualNetwork/subnets/default" ]
   linuxOSConfig:
     $ref: "ocean-linuxOSConfig.yaml"
+  localDnsProfile:
+    $ref: "ocean-localDnsProfile.yaml"

--- a/api/services/ocean/aks/schemas/update/ocean-nodePoolProperties.yaml
+++ b/api/services/ocean/aks/schemas/update/ocean-nodePoolProperties.yaml
@@ -57,3 +57,5 @@ properties:
     example: [ "/subscriptions/123456-1234-1234-1234-123456789/resourceGroups/ExampleResourceGroup/providers/Microsoft.Network/virtualNetworks/ExampleVirtualNetwork/subnets/default" ]
   linuxOSConfig:
     $ref: "../ocean-linuxOSConfig.yaml"
+  localDnsProfile:
+    $ref: "../ocean-localDnsProfile.yaml"


### PR DESCRIPTION
Adds `localDnsProfile` to VNG nodePoolProperties schema.

Changes:
- New schema: ocean-localDnsProfile.yaml (mode, vnetDNSOverrides, kubeDNSOverrides)
- ocean-nodePoolProperties.yaml: adds localDnsProfile ref (create/import)
- update/ocean-nodePoolProperties.yaml: adds localDnsProfile ref (update)