### PR TITLE
SOD-824: Add scalingOrientation (orientation) field to Ocean AKS VNG strategy

### DIFF
--- a/api/services/ocean/aks/schemas/ocean-strategy.yaml
+++ b/api/services/ocean/aks/schemas/ocean-strategy.yaml
@@ -21,6 +21,13 @@ properties:
     description: >
       If no spot instance markets are available, enable Ocean to launch on-demand instances instead.
     example: true
+  orientation:
+    type: string
+    description: >
+      Set this value to control and manage optimization priorities.
+    enum: [ cost, availability ]
+    example: cost
+    default: cost
   drainingTimeout:
     type: integer
     description: >


### PR DESCRIPTION
Jira: https://flexera.atlassian.net/browse/SOD-824

## What
Adds the `orientation` field to the shared `ocean-strategy.yaml` schema under `api/services/ocean/aks/schemas/`, used by the `strategy` object across all 4 Ocean AKS VNG operations (they all \$ref the same schema file):
- Create VNG (`oceanAKSVirtualNodeGroupCreate`)
- Get/List VNG (`oceanAKSVirtualNodeGroupGet` / `oceanAKSVirtualNodeGroupList`)
- Update VNG (`oceanAKSVirtualNodeGroupUpdate`)
- Import VNG (`oceanAKSVirtualNodeGroupImport`)

## Field
- Name: `orientation` (kept as-is to match the actual field name implemented in `spotinst-api` / `spotinst-azure-ocean-common` — the story named it `scalingOrientation`, but no rename was made in code, so the doc uses the real field name to stay accurate)
- Type: string, enum `[cost, availability]`
- Default: `cost`
- Description: "Set this value to control and manage optimization priorities."

## Verification
- `yarn validate` (swagger-cli validate) — pass
- `yarn bundle:swagger` — pass
- `npx @redocly/cli lint` — no new errors/warnings introduced (3 pre-existing errors unrelated to this file)
- `yarn bundle:redoc` fails on this branch **and equally on master** (pre-existing `redoc-cli` React "Invalid hook call" dependency conflict, unrelated to this change)

## Acceptance criteria
- [x] `orientation` appears under `strategy` for all 4 ops (shared schema)
- [x] Both values (`cost`, `availability`) documented via enum
- [x] Default `cost` stated
- [x] Samples auto-generated from schema `example: cost`